### PR TITLE
pass all props of tree item to TreeNode

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -34,19 +34,31 @@ function saveRef(name, component) {
 function loopTreeData(data, level = 0) {
   return data.map((item, index) => {
     const pos = `${level}-${index}`;
+    const {
+      label,
+      value,
+      disabled,
+      key,
+      hasOwnProperty,
+      selectable,
+      children,
+      isLeaf,
+      ...otherProps,
+    } = item;
     const props = {
-      title: item.label,
-      value: item.value,
-      // value: item.value || String(item.key || item.label), // cause onChange callback error
-      key: item.key || item.value || pos,
-      disabled: item.disabled || false,
-      selectable: item.hasOwnProperty('selectable') ? item.selectable : true,
+      value,
+      title: label,
+      // value: value || String(key || label), // cause onChange callback error
+      key: key || value || pos,
+      disabled: disabled || false,
+      selectable: selectable === false ? selectable : true,
+      ...otherProps,
     };
     let ret;
-    if (item.children && item.children.length) {
-      ret = (<_TreeNode {...props}>{loopTreeData(item.children, pos)}</_TreeNode>);
+    if (children && children.length) {
+      ret = (<_TreeNode {...props}>{loopTreeData(children, pos)}</_TreeNode>);
     } else {
-      ret = (<_TreeNode {...props} isLeaf={item.isLeaf}/>);
+      ret = (<_TreeNode {...props} isLeaf={isLeaf}/>);
     }
     return ret;
   });


### PR DESCRIPTION
The current loopTreeData does not pass all props of the data objects to the TreeNode. because of this, the treeNodeFilterProp of TreeSelect is limited to a small subset of the data.  With this fix, I can send this array to my tree data and filter on the itemName prop by setting the treeNodeLabelProp of TreeSelect.  Currently, TreeSelect default searching is happening against the value prop which causes issues if my value need to be the ID of a particular item.

```
const treeData = [
{
  selectable: false,
  label: <Tooltip title = "This item already has a template defined">
          <span className="disabled-item-label">item Supercool</span>
          </Tooltip>,
  itemName: 'item Supercool',
  value: '1',
  key: '1',
  id: '1',
  pId: null,
},
{
  label: <span className="item-label">Generic item</span>,
  itemName: 'Generic item',
  value: '2',
  key: '2',
  id: '2',
  pId: null,
},
{
  label: <span className="item-label">Generic item 2</span>,
  itemName: 'Generic item 2',
  value: '3',
  key: '3',
  id: '3',
  pId: '2',
},
{
  label: <span className="item-label">Supercool part 2</span>,
  itemName: 'Supercool part 2',
  value: '4',
  key: '4',
  id: '4',
  pId: '1',
},
{
  selectable: false,
  label: <Tooltip title = "This item already has a template defined">
            <span className = "disabled-item-label" > Supercool part 3 </span>
          </Tooltip>,
  itemName: 'Supercool part 3',
  value: '5',
  key: '5',
  id: '5',
  pId: '4',
},
]
```