### PR TITLE
fix:remove checked node error when enable search

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -593,7 +593,7 @@ const Select = React.createClass({
         unCheckPos = itemObj.pos;
       }
     });
-    const nArr = unCheckPos.split('-');
+    const nArr = unCheckPos && unCheckPos.split('-');
     const newVals = [];
     const newCkTns = [];
     checkedTreeNodes.forEach(itemObj => {


### PR DESCRIPTION
Bug fix.
Detailed steps to reproduce the bug:
1.  enable search, set treeCheckable true, set inputValue null
2. input some search words
3. check a tree node
4. remove it, fail

[Demo: check select](http://react-component.github.io/tree-select/examples/basic.html)