### PR TITLE
Fixed: backspace doesn't work when treeCheckStrictly is set to true

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -674,6 +674,9 @@ class Select extends Component {
       if (singleValue.value === selectedVal) {
         label = singleValue.label;
       }
+      if (selectedVal.value) {
+        return (singleValue.value !== selectedVal.value);
+      }
       return (singleValue.value !== selectedVal);
     });
     const canMultiple = isMultipleOrTags(props);


### PR DESCRIPTION
issue related to https://github.com/react-component/tree-select/issues/78

Please check the fix below.