### PR TITLE
Optimize node ancestor checks

### DIFF
--- a/examples/util.js
+++ b/examples/util.js
@@ -97,12 +97,17 @@ function loopData(data, callback) {
   loop(data);
 }
 
-function isInclude(smallArray, bigArray) {
-  return smallArray.every((ii, i) => {
-    return ii === bigArray[i];
-  });
+function isPositionPrefix(smallPos, bigPos) {
+  if (bigPos.length < smallPos.length) {
+    return false;
+  }
+  // attention: "0-0-1" "0-0-10"
+  if ((bigPos.length > smallPos.length) && (bigPos.charAt(smallPos.length) !== '-')) {
+    return false;
+  }
+  return bigPos.substr(0, smallPos.length) === smallPos;
 }
-// console.log(isInclude(['0', '1'], ['0', '10', '1']));
+// console.log(isPositionPrefix("0-1", "0-10-1"));
 
 export function getFilterValue(val, sVal, delVal) {
   const allPos = [];
@@ -117,12 +122,8 @@ export function getFilterValue(val, sVal, delVal) {
   });
   const newPos = [];
   delPos.forEach((item) => {
-    const nArr = item.split('-');
     allPos.forEach((i) => {
-      const iArr = i.split('-');
-      if (item === i ||
-        nArr.length > iArr.length && isInclude(iArr, nArr) ||
-        nArr.length < iArr.length && isInclude(nArr, iArr)) {
+      if (isPositionPrefix(item, i) || isPositionPrefix(i, item)) {
         // 过滤掉 父级节点 和 所有子节点。
         // 因为 node节点 不选时，其 父级节点 和 所有子节点 都不选。
         return;

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -11,7 +11,7 @@ import {
   UNSELECTABLE_ATTRIBUTE, UNSELECTABLE_STYLE,
   preventDefaultEvent,
   getTreeNodesStates, flatToHierarchy, filterParentPosition,
-  isInclude, labelCompatible, loopAllChildren, filterAllCheckedData,
+  isPositionPrefix, labelCompatible, loopAllChildren, filterAllCheckedData,
   processSimpleTreeData, saveRef,
 } from './util';
 import SelectTrigger from './SelectTrigger';
@@ -569,14 +569,10 @@ class Select extends Component {
         unCheckPos = itemObj.pos;
       }
     });
-    const nArr = unCheckPos && unCheckPos.split('-');
     const newVals = [];
     const newCkTns = [];
     checkedTreeNodes.forEach(itemObj => {
-      const iArr = itemObj.pos.split('-');
-      if (itemObj.pos === unCheckPos ||
-        nArr.length > iArr.length && isInclude(iArr, nArr) ||
-        nArr.length < iArr.length && isInclude(nArr, iArr)) {
+      if (isPositionPrefix(itemObj.pos, unCheckPos) || isPositionPrefix(unCheckPos, itemObj.pos)) {
         // Filter ancestral and children nodes when uncheck a node.
         return;
       }

--- a/src/util.js
+++ b/src/util.js
@@ -75,6 +75,17 @@ export function isInclude(smallArray, bigArray) {
   });
 }
 
+export function isPositionPrefix(smallPos, bigPos) {
+  if (bigPos.length < smallPos.length) {
+    return false;
+  }
+  // attention: "0-0-1" "0-0-10"
+  if ((bigPos.length > smallPos.length) && (bigPos.charAt(smallPos.length) !== '-')) {
+    return false;
+  }
+  return bigPos.substr(0, smallPos.length) === smallPos;
+}
+
 /*
 export function getCheckedKeys(node, checkedKeys, allCheckedNodesKeys) {
   const nodeKey = node.props.eventKey;
@@ -87,13 +98,9 @@ export function getCheckedKeys(node, checkedKeys, allCheckedNodesKeys) {
     }
   });
   if (unCheck) {
-    const nArr = nodePos.split('-');
     newCks = [];
     allCheckedNodesKeys.forEach(item => {
-      const iArr = item.pos.split('-');
-      if (item.pos === nodePos ||
-        nArr.length > iArr.length && isInclude(iArr, nArr) ||
-        nArr.length < iArr.length && isInclude(nArr, iArr)) {
+      if (isPositionPrefix(item.pos, nodePos) || isPositionPrefix(nodePos, item.pos)) {
         return;
       }
       newCks.push(item.key);
@@ -179,7 +186,7 @@ export function flatToHierarchy(arr) {
       levelObj[pre].forEach((item) => {
         let haveParent = false;
         levelObj[cur].forEach((ii) => {
-          if (isInclude(ii.pos.split('-'), item.pos.split('-'))) {
+          if (isPositionPrefix(ii.pos, item.pos)) {
             haveParent = true;
             if (!ii.children) {
               ii.children = [];
@@ -215,7 +222,7 @@ export function filterParentPosition(arr) {
       levelObj[levelArr[i]].forEach(ii => {
         for (let j = i + 1; j < levelArr.length; j++) {
           levelObj[levelArr[j]].forEach((_i, index) => {
-            if (isInclude(ii.split('-'), _i.split('-'))) {
+            if (isPositionPrefix(ii, _i)) {
               levelObj[levelArr[j]][index] = null;
             }
           });


### PR DESCRIPTION
Eliminate String.split() and compare position strings directly.

Gives huge performance boost when handling lots of nodes, e.g.
https://react-component.github.io/tree-select/examples/big-data.html