### PR TITLE
hide popup when select box is disabled

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -926,7 +926,7 @@ class Select extends Component {
         halfCheckedValues={this.halfCheckedValues}
         multiple={multiple}
         disabled={disabled}
-        visible={state.open}
+        visible={state.open && !disabled}
         inputValue={state.inputValue}
         inputElement={this.getInputElement()}
         value={state.value}


### PR DESCRIPTION
Why we need this changes?
Answer: When I am going to disabled the dropdown, still user can able to select items from tree list popup. So I just hiding the tree list popup when select box is disabled. 

  