### PR TITLE
Fix levels sorting

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -216,7 +216,7 @@ export function filterParentPosition(arr) {
     }
     levelObj[posLen].push(item);
   });
-  const levelArr = Object.keys(levelObj).sort();
+  const levelArr = Object.keys(levelObj).sort((a, b) => a - b);
   for (let i = 0; i < levelArr.length; i++) {
     if (levelArr[i + 1]) {
       levelObj[levelArr[i]].forEach(ii => {


### PR DESCRIPTION
[https://github.com/react-component/tree-select/blob/master/src/util.js#L219](https://github.com/react-component/tree-select/blob/master/src/util.js#L219)
Object.keys returns string, but levels should be sorted as numbers.

With default sort function unexpected behavior occurs, check it at [http://react-component.github.io/tree-select/examples/big-data.html](http://react-component.github.io/tree-select/examples/big-data.html) with values x:1 y:1 z: >7. It should select only one top parent node in normal check mode.

Thx!