### PR TITLE
Add onBeforeSelect callback for some nodes which cannot be selected

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -239,6 +239,7 @@ class Demo extends React.Component {
           onChange={this.onMultipleChange}
           onSelect={this.onSelect}
           allowClear
+          onBeforeSelect={(value, node) => (!node.props || !node.props.children)}
         />
 
         <h2>check select</h2>

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -67,6 +67,7 @@ export const SelectPropTypes = {
   transitionName: PropTypes.string,
   animation: PropTypes.string,
   choiceTransitionName: PropTypes.string,
+  onBeforeSelect: PropTypes.func,
   onClick: PropTypes.func,
   onChange: PropTypes.func,
   onSelect: PropTypes.func,

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -70,6 +70,7 @@ class Select extends Component {
     placeholder: '',
     searchPlaceholder: '',
     labelInValue: false,
+    onBeforeSelect: () => { return true; },
     onClick: noop,
     onChange: noop,
     onSelect: noop,
@@ -296,6 +297,10 @@ class Select extends Component {
     if (info.selected === false) {
       this.onDeselect(info);
       if (!checkableSelect) return;
+    }
+    if (!props.onBeforeSelect(event, item, info)) {
+      this.onDeselect(info);
+      return;
     }
     props.onSelect(event, item, info);
 


### PR DESCRIPTION
Solve the following problems:
![untitled](https://user-images.githubusercontent.com/1892857/37502493-e8f7bc6a-290d-11e8-8438-f117d1545fc6.png)
<img width="413" alt="treeselect-prevent-parent-items" src="https://user-images.githubusercontent.com/1892857/37502502-f324951e-290d-11e8-903c-31b5ac2b901a.png">
