### PR TITLE
do not expand tree after clear the input

### DIFF
--- a/src/Base/BasePopup.jsx
+++ b/src/Base/BasePopup.jsx
@@ -96,6 +96,15 @@ class BasePopup extends React.Component {
       newState.expandedKeyList = Object.keys(keyEntities);
     }
 
+    // do not expand tree after clear the input
+    if (
+      prevProps.filteredTreeNodes &&
+      prevProps.filteredTreeNodes.length &&
+      filteredTreeNodes === null
+    ) {
+      newState.expandedKeyList = [];
+    }
+        
     // Use expandedKeys if provided
     if (prevProps.treeExpandedKeys !== nextProps.treeExpandedKeys) {
       newState.expandedKeyList = nextProps.treeExpandedKeys;


### PR DESCRIPTION
I find that all nodes are expanded when starting the search.And In some cases
this component will request the api for many times.
1.Search the nodes.
2.Some nodes match the search string.
3.Delete all search text.
If some one need help to reproduce the problem please contact with me.