### PR TITLE
fix: scroll to show selected node, not its leafs

### DIFF
--- a/examples/form.js
+++ b/examples/form.js
@@ -15,6 +15,10 @@ import './demo.less';
 const { Option } = Select;
 
 class TreeSelectInput extends Component {
+  static propTypes = {
+    onChange: PropTypes.func,
+  };
+
   onChange = (value, ...args) => {
     console.log(value, ...args);
     const props = this.props;

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -441,6 +441,7 @@ class Select extends React.Component {
             scrollIntoView(domNode, triggerContainer, {
               onlyScrollIfNeeded: true,
               offsetTop: searchNode.offsetHeight,
+              alignWithTop: true,
             });
           }
         });


### PR DESCRIPTION
This is to fix <https://github.com/ant-design/ant-design/issues/18170>
If an item has long list of children, when it is selected, `scrollIntoView` should always align with top, as this selected item has large `height` (with all its children included), scroll to show last of its children does not meet user's expectation.

当选中节点有较长子节点列表的时候，`scrollIntoView` 的自动调节功能（<https://github.com/yiminghe/dom-scroll-into-view/blob/master/src/index.js#L102>）会选择显示底部的内容，最终显示出来的是最后的子节点，和用户的预期不符。这里通过 `alignWithTop` 强制让最顶部显示出来（这里最顶部就是用户选中的节点）
