### PR TITLE
fix treeRef.current.scrollTo throw error

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -130,7 +130,7 @@ const OptionList: React.RefForwardingComponent<
   React.useEffect(() => {
     // Single mode should scroll to current key
     if (open && !multiple && valueKeys.length) {
-      treeRef.current.scrollTo({ key: valueKeys[0] });
+      treeRef.current?.scrollTo({ key: valueKeys[0] });
     }
   }, [open]);
 

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -67,6 +67,10 @@ describe('TreeSelect.basic', () => {
       mount(<TreeSelect open />);
     });
 
+    it('not crash if no treeData', () => {
+      const wrapper = mount(<TreeSelect value="" treeData={[]} open />);
+    });
+
     it('renders disabled correctly', () => {
       const wrapper = mount(<TreeSelect disabled treeData={treeData} />);
       expect(wrapper.render()).toMatchSnapshot();


### PR DESCRIPTION
when treeData is empty

close ant-design/ant-design#21627