### PR TITLE
📦 Avoid multiple version of rc-xxx

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "dependencies": {
     "classnames": "2.x",
-    "rc-select": "^10.1.0",
-    "rc-tree": "^3.1.0",
+    "rc-select": "~10.1.0",
+    "rc-tree": "~3.1.0",
     "rc-util": "^4.17.0"
   }
 }


### PR DESCRIPTION
antd master 上现在有两个 rc-tree，避免未来也打入两份，底层需要固定版本。

<img width="458" alt="image" src="https://user-images.githubusercontent.com/507615/77250855-9d13eb80-6c85-11ea-9a06-fc6bf7a2b8a9.png">

我另外发个 PR 到 3.0.x 上。