### PR TITLE
📦 fix antd 4.0.x bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
   },
   "dependencies": {
     "classnames": "2.x",
-    "rc-select": "^10.0.0",
-    "rc-tree": "^3.0.0",
+    "rc-select": "~10.0.0",
+    "rc-tree": "~3.0.0",
     "rc-util": "^4.17.0"
   }
 }


### PR DESCRIPTION
详细见：#228

依赖和 antd 主干的依赖保持一致：https://github.com/ant-design/ant-design/blob/4.0.3/package.json