### PR TITLE
fix: treeNodeLabelProp should only work on result value

### DIFF
--- a/examples/treeNodeLabelProp.tsx
+++ b/examples/treeNodeLabelProp.tsx
@@ -1,6 +1,6 @@
 import '../assets/index.less';
 import React from 'react';
-import TreeSelect from '../src';
+import TreeSelect, { TreeNode } from '../src';
 
 const treeData = [
   {
@@ -12,12 +12,17 @@ const treeData = [
 
 function Demo() {
   return (
-    <TreeSelect
-      style={{ width: '100%' }}
-      treeDefaultExpandAll
-      treeData={treeData}
-      treeNodeLabelProp="showTitle"
-    />
+    <>
+      <TreeSelect
+        style={{ width: '100%' }}
+        treeDefaultExpandAll
+        treeData={treeData}
+        treeNodeLabelProp="showTitle"
+      />
+      <TreeSelect style={{ width: '100%' }} treeDefaultExpandAll treeNodeLabelProp="showTitle">
+        <TreeNode value="0-0" title="a list is option only" showTitle="Node2" />
+      </TreeSelect>
+    </>
   );
 }
 

--- a/examples/treeNodeLabelProp.tsx
+++ b/examples/treeNodeLabelProp.tsx
@@ -1,0 +1,24 @@
+import '../assets/index.less';
+import React from 'react';
+import TreeSelect from '../src';
+
+const treeData = [
+  {
+    title: 'a list is option only',
+    showTitle: 'Node2',
+    value: '0-1',
+  },
+];
+
+function Demo() {
+  return (
+    <TreeSelect
+      style={{ width: '100%' }}
+      treeDefaultExpandAll
+      treeData={treeData}
+      treeNodeLabelProp="showTitle"
+    />
+  );
+}
+
+export default Demo;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@babel/runtime": "^7.10.1",
     "classnames": "2.x",
     "rc-select": "^11.0.4",
-    "rc-tree": "^3.6.0",
-    "rc-util": "^5.0.1"
+    "rc-tree": "^3.8.0",
+    "rc-util": "^5.0.5"
   }
 }

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -5,6 +5,7 @@ import { convertDataToEntities } from 'rc-tree/lib/utils/treeUtil';
 import { conductCheck } from 'rc-tree/lib/utils/conductUtil';
 import { IconType } from 'rc-tree/lib/interface';
 import { FilterFunc, INTERNAL_PROPS_MARK } from 'rc-select/lib/interface/generator';
+import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import warning from 'rc-util/lib/warning';
 import OptionList from './OptionList';
 import TreeNode from './TreeNode';
@@ -235,8 +236,9 @@ const RefTreeSelect = React.forwardRef<RefSelectProps, TreeSelectProps>((props, 
   }, [mergedTreeData, treeCheckable, treeCheckStrictly]);
 
   // ========================= Value =========================
-  const [value, setValue] = React.useState<DefaultValueType>(props.defaultValue);
-  const mergedValue = 'value' in props ? props.value : value;
+  const [mergedValue, setValue] = useMergedState<DefaultValueType>(props.defaultValue, {
+    value: props.value,
+  });
 
   /** Get `missingRawValues` which not exist in the tree yet */
   const splitRawValues = (newRawValues: RawValueType[]) => {

--- a/tests/Select.tree.spec.js
+++ b/tests/Select.tree.spec.js
@@ -100,4 +100,29 @@ describe('TreeSelect.tree', () => {
 
     expect(wrapper.getSelection(0).text()).toEqual('empty string');
   });
+
+  describe('treeNodeLabelProp', () => {
+    [
+      { name: 'treeDate', treeData: [{ title: 'a light', op: 'Light', value: 'light' }] },
+      {
+        name: 'children',
+        children: <SelectNode title="a light" op="Light" value="light" />,
+      },
+    ].forEach(({ name, ...restProps }) => {
+      it(name, () => {
+        const wrapper = mount(
+          <TreeSelect
+            open
+            treeDefaultExpandAll
+            treeNodeLabelProp="op"
+            value="light"
+            {...restProps}
+          />,
+        );
+
+        expect(wrapper.find('.rc-tree-select-tree-title').text()).toEqual('a light');
+        expect(wrapper.find('.rc-tree-select-selection-item').text()).toEqual('Light');
+      });
+    });
+  });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/23079

v4 错误的把 treeNodeLabelProp 作用到了 Tree 中，它应该只作用到 option values 里

虽然是个 bug 但是也是个 breaking change，要发 minor

