### PR TITLE
fix: TreeSelect should not generate children when it's undefined

### DIFF
--- a/src/hooks/useTreeData.ts
+++ b/src/hooks/useTreeData.ts
@@ -100,7 +100,7 @@ function formatTreeData(
         valueSet.add(value);
       }
 
-      if (fieldChildren in node) {
+      if (node[fieldChildren] !== undefined) {
         dataNode.children = dig(node[fieldChildren]);
       }
 

--- a/tests/Select.tree.spec.js
+++ b/tests/Select.tree.spec.js
@@ -146,4 +146,23 @@ describe('TreeSelect.tree', () => {
 
     expect(wrapper.exists('.bamboo-light')).toBeTruthy();
   });
+
+  // https://github.com/ant-design/ant-design/issues/32806
+  it('OptionList should get empty children instead of list', () => {
+    const wrapper = mount(
+      <TreeSelect
+        open
+        treeData={[
+          {
+            title: 'bamboo',
+            value: 'bamboo',
+            children: undefined,
+          },
+        ]}
+      />,
+    );
+
+    const options = wrapper.find('OptionList').prop('options');
+    expect(options[0].children).toBeFalsy();
+  });
 });


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/32806