### PR TITLE
fix: onOptionSelect should check selectedValue is or isn't be null

### DIFF
--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -536,7 +536,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
         // Single mode always set value
         triggerChange([selectedValue], { selected: true, triggerValue: selectedValue }, 'option');
       } else {
-        let newRawValues = selected
+        let newRawValues = selected && selectedValue !== null
           ? [...rawValues, selectedValue]
           : rawCheckedValues.filter(v => v !== selectedValue);
 


### PR DESCRIPTION
If I press Enter after the input does not match any entries, the component returns a null value and renders an empty component on the page. like:

![image](https://user-images.githubusercontent.com/7866330/149892737-35025656-7273-4931-8304-7daa8b75c566.png)

so we should check the selectedValue is null