### PR TITLE
Fix typescript types for onSelect

### DIFF
--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -124,8 +124,8 @@ export interface TreeSelectProps<
   treeNodeFilterProp?: string;
 
   // >>> Select
-  onSelect?: SelectProps<ValueType,OptionType>['onSelect'];
-  onDeselect?: SelectProps<ValueType,OptionType>['onDeselect'];
+  onSelect?: SelectProps<ValueType, OptionType>['onSelect'];
+  onDeselect?: SelectProps<ValueType, OptionType>['onDeselect'];
 
   // >>> Selector
   showCheckedStrategy?: CheckedStrategy;

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -124,8 +124,8 @@ export interface TreeSelectProps<
   treeNodeFilterProp?: string;
 
   // >>> Select
-  onSelect?: SelectProps<OptionType>['onSelect'];
-  onDeselect?: SelectProps<OptionType>['onDeselect'];
+  onSelect?: SelectProps<ValueType,OptionType>['onSelect'];
+  onDeselect?: SelectProps<ValueType,OptionType>['onDeselect'];
 
   // >>> Selector
   showCheckedStrategy?: CheckedStrategy;


### PR DESCRIPTION
Closes https://github.com/ant-design/ant-design/issues/34375

[SelectProps](https://github.com/react-component/select/blob/master/src/Select.tsx#L98) needs to accept ValueType as it's first generic.

Right now, the type needs to be cast as any in order to work first.

Repro that shows arguments are not inferred and can be cast incorrectly: https://codesandbox.io/s/antd-typescript-forked-srs8ob?file=/demo.tsx

