### PR TITLE
build: correct es2lib for rc-select import statements

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     alias: {
       'rc-util/lib': 'rc-util/es',
       'rc-tree/lib': 'rc-tree/es',
+      'rc-select/lib': 'rc-select/es',
     },
   },
 });


### PR DESCRIPTION
修复 rc-tree 的 es to lib 规则