### PR TITLE
build: use rc father plugin

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -1,13 +1,5 @@
 import { defineConfig } from 'father';
 
 export default defineConfig({
-  platform: 'browser',
-  cjs: { output: 'lib' },
-  esm: {
-    output: 'es',
-    alias: {
-      'rc-util/lib': 'rc-util/es',
-      'rc-tree/lib': 'rc-tree/es',
-    },
-  },
+  plugins: ['@rc-component/father-plugin'],
 });

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "*"
   },
   "devDependencies": {
+    "@rc-component/father-plugin": "^1.0.0",
     "@testing-library/react": "^12.0.0",
     "@types/jest": "^26.0.5",
     "@types/react": "^16.8.19",


### PR DESCRIPTION
使用 `@rc-component/father-plugin` 替代手动的 father 构建配置，内含 lib2es 的 babel 插件