### PR TITLE
fix: aria-live not reading aria-label

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -211,7 +211,7 @@ const OptionList: React.RefForwardingComponent<ReviseRefOptionListProps> = (_, r
     <div onMouseDown={onListMouseDown}>
       {activeEntity && open && (
         <span style={HIDDEN_STYLE} aria-live="assertive">
-          {activeEntity.node.value}
+          {activeEntity.node['aria-label'] || activeEntity.node.value}
         </span>
       )}
 


### PR DESCRIPTION
Related issue: https://github.com/ant-design/ant-design/issues/40055

Aria-live should prefer aria-label over value.

