### PR TITLE
fix: `loadData` not keep fresh

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -10,7 +10,6 @@ import LegacyContext from './LegacyContext';
 import TreeSelectContext from './TreeSelectContext';
 import type { Key, SafeKey } from './interface';
 import { getAllKeys, isCheckDisabled } from './utils/valueUtil';
-import { useEvent } from 'rc-util';
 
 const HIDDEN_STYLE = {
   width: 0,

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -242,14 +242,14 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     onKeyUp: () => {},
   }));
 
-  const syncLoadData = useEvent(loadData);
-
-  const loadDataFun = useMemo(
-    () => (searchValue ? null : (syncLoadData as any)),
+  const hasLoadDataFn = useMemo(
+    () => (searchValue ? false : true),
     [searchValue, treeExpandedKeys || expandedKeys],
     ([preSearchValue], [nextSearchValue, nextExcludeSearchExpandedKeys]) =>
       preSearchValue !== nextSearchValue && !!(nextSearchValue || nextExcludeSearchExpandedKeys),
   );
+
+  const syncLoadData = hasLoadDataFn ? loadData : null;
 
   // ========================== Render ==========================
   if (memoTreeData.length === 0) {
@@ -292,7 +292,7 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
         showIcon={showTreeIcon}
         switcherIcon={switcherIcon}
         showLine={treeLine}
-        loadData={loadDataFun}
+        loadData={syncLoadData}
         motion={treeMotion}
         activeKey={activeKey}
         // We handle keys by out instead tree self

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -10,6 +10,7 @@ import LegacyContext from './LegacyContext';
 import TreeSelectContext from './TreeSelectContext';
 import type { Key, SafeKey } from './interface';
 import { getAllKeys, isCheckDisabled } from './utils/valueUtil';
+import { useEvent } from 'rc-util';
 
 const HIDDEN_STYLE = {
   width: 0,
@@ -241,17 +242,13 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     onKeyUp: () => {},
   }));
 
+  const syncLoadData = useEvent(loadData);
+
   const loadDataFun = useMemo(
-    () => (searchValue ? null : (loadData as any)),
-    [loadData, searchValue, treeExpandedKeys || expandedKeys],
-    (
-      [prevLoadData, preSearchValue],
-      [nextLoadData, nextSearchValue, nextExcludeSearchExpandedKeys],
-    ) =>
-      // `loadData` changed
-      prevLoadData !== nextLoadData ||
-      // `searchValue` changed and not in search mode
-      (preSearchValue !== nextSearchValue && !!(nextSearchValue || nextExcludeSearchExpandedKeys)),
+    () => (searchValue ? null : (syncLoadData as any)),
+    [searchValue, treeExpandedKeys || expandedKeys],
+    ([preSearchValue], [nextSearchValue, nextExcludeSearchExpandedKeys]) =>
+      preSearchValue !== nextSearchValue && !!(nextSearchValue || nextExcludeSearchExpandedKeys),
   );
 
   // ========================== Render ==========================

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -243,9 +243,15 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
 
   const loadDataFun = useMemo(
     () => (searchValue ? null : (loadData as any)),
-    [searchValue, treeExpandedKeys || expandedKeys],
-    ([preSearchValue], [nextSearchValue, nextExcludeSearchExpandedKeys]) =>
-      preSearchValue !== nextSearchValue && !!(nextSearchValue || nextExcludeSearchExpandedKeys),
+    [loadData, searchValue, treeExpandedKeys || expandedKeys],
+    (
+      [prevLoadData, preSearchValue],
+      [nextLoadData, nextSearchValue, nextExcludeSearchExpandedKeys],
+    ) =>
+      // `loadData` changed
+      prevLoadData !== nextLoadData ||
+      // `searchValue` changed and not in search mode
+      (preSearchValue !== nextSearchValue && !!(nextSearchValue || nextExcludeSearchExpandedKeys)),
   );
 
   // ========================== Render ==========================

--- a/tests/Select.loadData.spec.tsx
+++ b/tests/Select.loadData.spec.tsx
@@ -1,16 +1,11 @@
 /* eslint-disable no-undef, react/no-multi-comp, no-console */
-import Tree, { TreeNode } from 'rc-tree';
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 
-import TreeSelect, { SHOW_ALL, SHOW_CHILD, SHOW_PARENT, TreeNode as SelectNode } from '../src';
-import { selectNode } from './util';
+import TreeSelect from '../src';
 
 describe('TreeSelect.loadData', () => {
   it('keep sync', async () => {
-    let renderTimes = 0;
-    let calledLastId: number | null = null;
-
     const Demo = () => {
       const [treeData, setTreeData] = React.useState([
         {
@@ -20,17 +15,15 @@ describe('TreeSelect.loadData', () => {
         },
       ]);
 
-      renderTimes += 1;
-      const renderId = renderTimes;
-
       const loadData = async () => {
-        calledLastId = renderId;
+        const nextId = treeData.length;
+
         setTreeData([
           ...treeData,
           {
-            title: `${renderId}`,
-            value: renderId,
-            isLeaf: true,
+            title: `${nextId}`,
+            value: nextId,
+            isLeaf: false,
           },
         ]);
       };
@@ -40,18 +33,14 @@ describe('TreeSelect.loadData', () => {
 
     render(<Demo />);
 
-    console.log(document.body.innerHTML);
-
-    fireEvent.click(document.querySelector('.rc-tree-select-tree-switcher_close'));
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(calledLastId).toBe(renderTimes);
-
-    fireEvent.click(document.querySelector('.rc-tree-select-tree-switcher_close'));
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(calledLastId).toBe(renderTimes);
+    for (let i = 0; i < 5; i += 1) {
+      fireEvent.click(document.querySelector('.rc-tree-select-tree-switcher_close'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(
+        document.querySelectorAll('.rc-tree-select-tree-list .rc-tree-select-tree-treenode'),
+      ).toHaveLength(2 + i);
+    }
   });
 });

--- a/tests/Select.loadData.spec.tsx
+++ b/tests/Select.loadData.spec.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef, react/no-multi-comp, no-console */
+import Tree, { TreeNode } from 'rc-tree';
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+
+import TreeSelect, { SHOW_ALL, SHOW_CHILD, SHOW_PARENT, TreeNode as SelectNode } from '../src';
+import { selectNode } from './util';
+
+describe('TreeSelect.loadData', () => {
+  it('keep sync', async () => {
+    let renderTimes = 0;
+    let calledLastId: number | null = null;
+
+    const Demo = () => {
+      const [treeData, setTreeData] = React.useState([
+        {
+          title: '0',
+          value: 0,
+          isLeaf: false,
+        },
+      ]);
+
+      renderTimes += 1;
+      const renderId = renderTimes;
+
+      const loadData = async () => {
+        calledLastId = renderId;
+        setTreeData([
+          ...treeData,
+          {
+            title: `${renderId}`,
+            value: renderId,
+            isLeaf: true,
+          },
+        ]);
+      };
+
+      return <TreeSelect open treeData={treeData} loadData={loadData} />;
+    };
+
+    render(<Demo />);
+
+    console.log(document.body.innerHTML);
+
+    fireEvent.click(document.querySelector('.rc-tree-select-tree-switcher_close'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(calledLastId).toBe(renderTimes);
+
+    fireEvent.click(document.querySelector('.rc-tree-select-tree-switcher_close'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(calledLastId).toBe(renderTimes);
+  });
+});


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/51724

ref: https://github.com/react-component/tree-select/pull/576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了 `OptionList` 组件的数据加载逻辑，提升了组件对外部事件的响应能力。
  - 允许外部组件控制滚动行为。

- **测试**
  - 引入了针对 `TreeSelect` 组件的新测试套件，验证树数据的动态加载。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->