### PR TITLE
feat: supplement maxCount logic for complicated cases

### DIFF
--- a/examples/mutiple-with-maxCount.tsx
+++ b/examples/mutiple-with-maxCount.tsx
@@ -80,7 +80,6 @@ export default () => {
       <h2>checkable with maxCount</h2>
       <TreeSelect
         style={{ width: 300 }}
-        multiple
         treeCheckable
         // showCheckedStrategy="SHOW_ALL"
         // showCheckedStrategy="SHOW_PARENT"

--- a/examples/mutiple-with-maxCount.tsx
+++ b/examples/mutiple-with-maxCount.tsx
@@ -77,7 +77,6 @@ export default () => {
         maxCount={3}
         treeData={treeData}
       />
-
       <h2>checkable with maxCount</h2>
       <TreeSelect
         style={{ width: 300 }}
@@ -90,7 +89,6 @@ export default () => {
         onChange={onChange}
         value={value}
       />
-
       <h2>checkable with maxCount and treeCheckStrictly</h2>
       <TreeSelect
         style={{ width: 300 }}

--- a/examples/mutiple-with-maxCount.tsx
+++ b/examples/mutiple-with-maxCount.tsx
@@ -20,6 +20,20 @@ export default () => {
           key: '1-2',
           value: '1-2',
           title: '1-2',
+          disabled: true,
+          children: [
+            {
+              key: '1-2-1',
+              value: '1-2-1',
+              title: '1-2-1',
+              disabled: true,
+            },
+            {
+              key: '1-2-2',
+              value: '1-2-2',
+              title: '1-2-2',
+            },
+          ],
         },
         {
           key: '1-3',
@@ -70,8 +84,7 @@ export default () => {
         multiple
         treeCheckable
         // showCheckedStrategy="SHOW_ALL"
-        showCheckedStrategy="SHOW_PARENT"
-        // showCheckedStrategy="SHOW_CHILD"
+        // showCheckedStrategy="SHOW_PARENT"
         maxCount={4}
         treeData={treeData}
         onChange={onChange}

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -9,10 +9,9 @@ import useMemo from 'rc-util/lib/hooks/useMemo';
 import * as React from 'react';
 import LegacyContext from './LegacyContext';
 import TreeSelectContext from './TreeSelectContext';
-import type { DataNode, FieldNames, Key, SafeKey } from './interface';
+import type { DataNode, Key, SafeKey } from './interface';
 import { getAllKeys, isCheckDisabled } from './utils/valueUtil';
 import { useEvent } from 'rc-util';
-import { formatStrategyValues } from './utils/strategyUtil';
 
 const HIDDEN_STYLE = {
   width: 0,

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -49,7 +49,8 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     treeTitleRender,
     onPopupScroll,
     leftMaxCount,
-    showCheckedStrategy,
+    leafCountOnly,
+    valueEntities,
   } = React.useContext(TreeSelectContext);
 
   const {
@@ -180,10 +181,14 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
       return false;
     }
 
-    console.log('--->', node);
+    // console.log('--->', node);
 
     if (leftMaxCount === null) {
       return false;
+    }
+
+    if (!leafCountOnly && leftMaxCount <= 0) {
+      return true;
     }
 
     // const cacheKey = `${nodeValue}-${checkedKeys.join(',')}-${maxCount}`;

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -180,6 +180,8 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
       return false;
     }
 
+    console.log('--->', node);
+
     if (leftMaxCount === null) {
       return false;
     }

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -13,7 +13,6 @@ import type { DataNode, FieldNames, Key, SafeKey } from './interface';
 import { getAllKeys, isCheckDisabled } from './utils/valueUtil';
 import { useEvent } from 'rc-util';
 import { formatStrategyValues } from './utils/strategyUtil';
-import { conductCheck } from 'rc-tree/lib/utils/conductUtil';
 
 const HIDDEN_STYLE = {
   width: 0,
@@ -210,9 +209,8 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     // calculate disabled state
     const selectableNodeKeys = getSelectableKeys(node, fieldNames);
     const simulatedCheckedKeys = [...checkedKeys, ...selectableNodeKeys];
-    const { checkedKeys: conductedKeys } = conductCheck(simulatedCheckedKeys, true, keyEntities);
     const simulatedDisplayValues = formatStrategyValues(
-      conductedKeys as SafeKey[],
+      simulatedCheckedKeys as SafeKey[],
       showCheckedStrategy,
       keyEntities,
       fieldNames,

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -175,15 +175,15 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     resetCache();
   }, [checkedKeys, maxCount]);
 
-  const getSelectableKeys = (targetNode: DataNode, fieldNames: FieldNames): Key[] => {
-    const keys = [targetNode[fieldNames.value]];
+  const getSelectableKeys = (targetNode: DataNode, names: FieldNames): Key[] => {
+    const keys = [targetNode[names.value]];
     if (!Array.isArray(targetNode.children)) {
       return keys;
     }
 
     return targetNode.children.reduce((acc, child) => {
       if (!child.disabled) {
-        acc.push(...getSelectableKeys(child, fieldNames));
+        acc.push(...getSelectableKeys(child, names));
       }
       return acc;
     }, keys);

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -48,8 +48,7 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     treeExpandAction,
     treeTitleRender,
     onPopupScroll,
-    isOverMaxCount,
-    maxCount,
+    leftMaxCount,
     showCheckedStrategy,
   } = React.useContext(TreeSelectContext);
 
@@ -160,33 +159,19 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchValue]);
 
-  const disabledCacheRef = React.useRef(new Map<Key, boolean>());
-  const lastCheckedKeysRef = React.useRef<Key[]>([]);
-  const lastMaxCountRef = React.useRef<number>(null);
+  // const getSelectableKeys = (targetNode: DataNode, names: FieldNames): Key[] => {
+  //   const keys = [targetNode[names.value]];
+  //   if (!Array.isArray(targetNode.children)) {
+  //     return keys;
+  //   }
 
-  const resetCache = React.useCallback(() => {
-    disabledCacheRef.current.clear();
-    lastCheckedKeysRef.current = [...checkedKeys];
-    lastMaxCountRef.current = maxCount;
-  }, [checkedKeys, maxCount]);
-
-  React.useEffect(() => {
-    resetCache();
-  }, [checkedKeys, maxCount]);
-
-  const getSelectableKeys = (targetNode: DataNode, names: FieldNames): Key[] => {
-    const keys = [targetNode[names.value]];
-    if (!Array.isArray(targetNode.children)) {
-      return keys;
-    }
-
-    return targetNode.children.reduce((acc, child) => {
-      if (!child.disabled) {
-        acc.push(...getSelectableKeys(child, names));
-      }
-      return acc;
-    }, keys);
-  };
+  //   return targetNode.children.reduce((acc, child) => {
+  //     if (!child.disabled) {
+  //       acc.push(...getSelectableKeys(child, names));
+  //     }
+  //     return acc;
+  //   }, keys);
+  // };
 
   const nodeDisabled = useEvent((node: DataNode) => {
     const nodeValue = node[fieldNames.value];
@@ -195,33 +180,35 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
       return false;
     }
 
-    if (isOverMaxCount) {
-      return true;
+    if (leftMaxCount === null) {
+      return false;
     }
 
-    const cacheKey = `${nodeValue}-${checkedKeys.join(',')}-${maxCount}`;
+    // const cacheKey = `${nodeValue}-${checkedKeys.join(',')}-${maxCount}`;
 
-    // check cache
-    if (disabledCacheRef.current.has(cacheKey)) {
-      return disabledCacheRef.current.get(cacheKey);
-    }
+    // // check cache
+    // if (disabledCacheRef.current.has(cacheKey)) {
+    //   return disabledCacheRef.current.get(cacheKey);
+    // }
 
-    // calculate disabled state
-    const selectableNodeKeys = getSelectableKeys(node, fieldNames);
-    const simulatedCheckedKeys = [...checkedKeys, ...selectableNodeKeys];
-    const simulatedDisplayValues = formatStrategyValues(
-      simulatedCheckedKeys as SafeKey[],
-      showCheckedStrategy,
-      keyEntities,
-      fieldNames,
-    );
+    // // calculate disabled state
+    // const selectableNodeKeys = getSelectableKeys(node, fieldNames);
+    // const simulatedCheckedKeys = [...checkedKeys, ...selectableNodeKeys];
+    // const simulatedDisplayValues = formatStrategyValues(
+    //   simulatedCheckedKeys as SafeKey[],
+    //   showCheckedStrategy,
+    //   keyEntities,
+    //   fieldNames,
+    // );
 
-    const isDisabled = simulatedDisplayValues.length > maxCount;
+    // const isDisabled = simulatedDisplayValues.length > maxCount;
 
-    // update cache
-    disabledCacheRef.current.set(cacheKey, isDisabled);
+    // // update cache
+    // disabledCacheRef.current.set(cacheKey, isDisabled);
 
-    return isDisabled;
+    // return isDisabled;
+
+    return false;
   });
 
   // ========================== Get First Selectable Node ==========================

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -625,6 +625,8 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
       onPopupScroll,
       displayValues: cachedDisplayValues,
       isOverMaxCount,
+      maxCount,
+      showCheckedStrategy: mergedShowCheckedStrategy,
     };
   }, [
     virtual,
@@ -641,6 +643,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
     maxCount,
     cachedDisplayValues,
     mergedMultiple,
+    mergedShowCheckedStrategy,
   ]);
 
   // ======================= Legacy Context =======================

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -422,6 +422,11 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
         mergedFieldNames,
       );
 
+      // Not allow pass with `maxCount`
+      if (maxCount && formattedKeyList.length > maxCount) {
+        return;
+      }
+
       const labeledValues = convert2LabelValues(newRawValues);
       setInternalValue(labeledValues);
 
@@ -600,9 +605,6 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
   });
 
   // ========================== Context ===========================
-  const isOverMaxCount =
-    mergedMultiple && maxCount !== undefined && cachedDisplayValues?.length >= maxCount;
-
   const treeSelectContext = React.useMemo<TreeSelectContextProps>(() => {
     return {
       virtual,
@@ -616,8 +618,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
       treeExpandAction,
       treeTitleRender,
       onPopupScroll,
-      isOverMaxCount,
-      maxCount,
+      leftMaxCount: maxCount ? maxCount - cachedDisplayValues.length : null,
       showCheckedStrategy: mergedShowCheckedStrategy,
     };
   }, [
@@ -633,7 +634,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
     treeTitleRender,
     onPopupScroll,
     maxCount,
-    mergedMultiple,
+    cachedDisplayValues.length,
     mergedShowCheckedStrategy,
   ]);
 

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -422,8 +422,6 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
         mergedFieldNames,
       );
 
-      console.log('triggerChange');
-
       const labeledValues = convert2LabelValues(newRawValues);
       setInternalValue(labeledValues);
 

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -226,6 +226,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
   const mergedTreeData = useTreeData(treeData, children, treeDataSimpleMode);
 
   const { keyEntities, valueEntities } = useDataEntities(mergedTreeData, mergedFieldNames);
+  console.log('-->', valueEntities);
 
   /** Get `missingRawValues` which not exist in the tree yet */
   const splitRawValues = React.useCallback(
@@ -630,7 +631,9 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
       treeTitleRender,
       onPopupScroll,
       leftMaxCount: maxCount ? maxCount - cachedDisplayValues.length : null,
-      showCheckedStrategy: mergedShowCheckedStrategy,
+      leafCountOnly:
+        mergedShowCheckedStrategy === 'SHOW_CHILD' && !treeCheckStrictly && !!treeCheckable,
+      valueEntities,
     };
   }, [
     virtual,
@@ -647,6 +650,9 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
     maxCount,
     cachedDisplayValues.length,
     mergedShowCheckedStrategy,
+    treeCheckStrictly,
+    treeCheckable,
+    valueEntities,
   ]);
 
   // ======================= Legacy Context =======================

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -408,6 +408,17 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
 
   const [cachedDisplayValues] = useCache(displayValues);
 
+  // ========================== MaxCount ==========================
+  const mergedMaxCount = React.useMemo(() => {
+    if (
+      mergedMultiple &&
+      (mergedShowCheckedStrategy === 'SHOW_CHILD' || treeCheckStrictly || !treeCheckable)
+    ) {
+      return maxCount;
+    }
+    return null;
+  }, [maxCount, mergedMultiple, treeCheckStrictly, mergedShowCheckedStrategy, treeCheckable]);
+
   // =========================== Change ===========================
   const triggerChange = useRefFunc(
     (
@@ -423,7 +434,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
       );
 
       // Not allow pass with `maxCount`
-      if (maxCount && formattedKeyList.length > maxCount) {
+      if (mergedMaxCount && formattedKeyList.length > mergedMaxCount) {
         return;
       }
 

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -422,13 +422,6 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
         mergedFieldNames,
       );
 
-      // if multiple and maxCount is set, check if exceed maxCount
-      if (mergedMultiple && maxCount !== undefined) {
-        if (formattedKeyList.length > maxCount) {
-          return;
-        }
-      }
-
       const labeledValues = convert2LabelValues(newRawValues);
       setInternalValue(labeledValues);
 

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -629,7 +629,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
       treeExpandAction,
       treeTitleRender,
       onPopupScroll,
-      leftMaxCount: maxCount ? maxCount - cachedDisplayValues.length : null,
+      leftMaxCount: maxCount === undefined ? null : maxCount - cachedDisplayValues.length,
       leafCountOnly:
         mergedShowCheckedStrategy === 'SHOW_CHILD' && !treeCheckStrictly && !!treeCheckable,
       valueEntities,

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -422,6 +422,8 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
         mergedFieldNames,
       );
 
+      console.log('triggerChange');
+
       const labeledValues = convert2LabelValues(newRawValues);
       setInternalValue(labeledValues);
 
@@ -616,7 +618,6 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
       treeExpandAction,
       treeTitleRender,
       onPopupScroll,
-      displayValues: cachedDisplayValues,
       isOverMaxCount,
       maxCount,
       showCheckedStrategy: mergedShowCheckedStrategy,
@@ -634,7 +635,6 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
     treeTitleRender,
     onPopupScroll,
     maxCount,
-    cachedDisplayValues,
     mergedMultiple,
     mergedShowCheckedStrategy,
   ]);

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -226,7 +226,6 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
   const mergedTreeData = useTreeData(treeData, children, treeDataSimpleMode);
 
   const { keyEntities, valueEntities } = useDataEntities(mergedTreeData, mergedFieldNames);
-  console.log('-->', valueEntities);
 
   /** Get `missingRawValues` which not exist in the tree yet */
   const splitRawValues = React.useCallback(

--- a/src/TreeSelectContext.ts
+++ b/src/TreeSelectContext.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { ExpandAction } from 'rc-tree/lib/Tree';
 import type { DataNode, FieldNames, Key } from './interface';
-import type { CheckedStrategy } from './utils/strategyUtil';
+import type useDataEntities from './hooks/useDataEntities';
 
 export interface TreeSelectContextProps {
   virtual?: boolean;
@@ -15,8 +15,12 @@ export interface TreeSelectContextProps {
   treeExpandAction?: ExpandAction;
   treeTitleRender?: (node: any) => React.ReactNode;
   onPopupScroll?: React.UIEventHandler<HTMLDivElement>;
-  leftMaxCount?: number | null;
-  showCheckedStrategy?: CheckedStrategy;
+
+  // For `maxCount` usage
+  leftMaxCount: number | null;
+  /** When `true`, only take leaf node as count, or take all as count with `maxCount` limitation */
+  leafCountOnly: boolean;
+  valueEntities: ReturnType<typeof useDataEntities>['valueEntities'];
 }
 
 const TreeSelectContext = React.createContext<TreeSelectContextProps>(null as any);

--- a/src/TreeSelectContext.ts
+++ b/src/TreeSelectContext.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { ExpandAction } from 'rc-tree/lib/Tree';
 import type { DataNode, FieldNames, Key } from './interface';
-import { CheckedStrategy } from './utils/strategyUtil';
+import type { CheckedStrategy } from './utils/strategyUtil';
 
 export interface TreeSelectContextProps {
   virtual?: boolean;
@@ -15,8 +15,7 @@ export interface TreeSelectContextProps {
   treeExpandAction?: ExpandAction;
   treeTitleRender?: (node: any) => React.ReactNode;
   onPopupScroll?: React.UIEventHandler<HTMLDivElement>;
-  isOverMaxCount?: boolean;
-  maxCount?: number;
+  leftMaxCount?: number | null;
   showCheckedStrategy?: CheckedStrategy;
 }
 

--- a/src/TreeSelectContext.ts
+++ b/src/TreeSelectContext.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { ExpandAction } from 'rc-tree/lib/Tree';
 import type { DataNode, FieldNames, Key, LabeledValueType } from './interface';
+import { CheckedStrategy } from './utils/strategyUtil';
 
 export interface TreeSelectContextProps {
   virtual?: boolean;
@@ -16,6 +17,8 @@ export interface TreeSelectContextProps {
   onPopupScroll?: React.UIEventHandler<HTMLDivElement>;
   displayValues?: LabeledValueType[];
   isOverMaxCount?: boolean;
+  maxCount?: number;
+  showCheckedStrategy?: CheckedStrategy;
 }
 
 const TreeSelectContext = React.createContext<TreeSelectContextProps>(null as any);

--- a/src/TreeSelectContext.ts
+++ b/src/TreeSelectContext.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { ExpandAction } from 'rc-tree/lib/Tree';
-import type { DataNode, FieldNames, Key, LabeledValueType } from './interface';
+import type { DataNode, FieldNames, Key } from './interface';
 import { CheckedStrategy } from './utils/strategyUtil';
 
 export interface TreeSelectContextProps {

--- a/src/TreeSelectContext.ts
+++ b/src/TreeSelectContext.ts
@@ -15,7 +15,6 @@ export interface TreeSelectContextProps {
   treeExpandAction?: ExpandAction;
   treeTitleRender?: (node: any) => React.ReactNode;
   onPopupScroll?: React.UIEventHandler<HTMLDivElement>;
-  displayValues?: LabeledValueType[];
   isOverMaxCount?: boolean;
   maxCount?: number;
   showCheckedStrategy?: CheckedStrategy;

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -10,6 +10,8 @@ function warningProps(props: TreeSelectProps & { searchPlaceholder?: string }) {
     labelInValue,
     value,
     multiple,
+    showCheckedStrategy,
+    maxCount,
   } = props;
 
   warning(!searchPlaceholder, '`searchPlaceholder` has been removed.');
@@ -20,7 +22,7 @@ function warningProps(props: TreeSelectProps & { searchPlaceholder?: string }) {
 
   if (labelInValue || treeCheckStrictly) {
     warning(
-      toArray(value).every((val) => val && typeof val === 'object' && 'value' in val),
+      toArray(value).every(val => val && typeof val === 'object' && 'value' in val),
       'Invalid prop `value` supplied to `TreeSelect`. You should use { label: string, value: string | number } or [{ label: string, value: string | number }] instead.',
     );
   }
@@ -32,6 +34,13 @@ function warningProps(props: TreeSelectProps & { searchPlaceholder?: string }) {
     );
   } else {
     warning(!Array.isArray(value), '`value` should not be array when `TreeSelect` is single mode.');
+  }
+
+  if (maxCount && (showCheckedStrategy === 'SHOW_ALL' || showCheckedStrategy === 'SHOW_PARENT')) {
+    warning(
+      false,
+      '`maxCount` not work with `showCheckedStrategy=SHOW_ALL` or `showCheckedStrategy=SHOW_PARENT`.',
+    );
   }
 }
 

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -36,10 +36,14 @@ function warningProps(props: TreeSelectProps & { searchPlaceholder?: string }) {
     warning(!Array.isArray(value), '`value` should not be array when `TreeSelect` is single mode.');
   }
 
-  if (maxCount && (showCheckedStrategy === 'SHOW_ALL' || showCheckedStrategy === 'SHOW_PARENT')) {
+  if (
+    maxCount &&
+    ((showCheckedStrategy === 'SHOW_ALL' && !treeCheckStrictly) ||
+      showCheckedStrategy === 'SHOW_PARENT')
+  ) {
     warning(
       false,
-      '`maxCount` not work with `showCheckedStrategy=SHOW_ALL` or `showCheckedStrategy=SHOW_PARENT`.',
+      '`maxCount` not work with `showCheckedStrategy=SHOW_ALL` (when `treeCheckStrictly=false`) or `showCheckedStrategy=SHOW_PARENT`.',
     );
   }
 }

--- a/tests/Select.maxCount.spec.tsx
+++ b/tests/Select.maxCount.spec.tsx
@@ -372,3 +372,132 @@ describe('TreeSelect.maxCount with treeCheckStrictly', () => {
     expect(handleChange).toHaveBeenCalledTimes(4);
   });
 });
+
+describe('TreeSelect.maxCount with complex scenarios', () => {
+  const complexTreeData = [
+    {
+      key: 'asia',
+      value: 'asia',
+      title: 'Asia',
+      children: [
+        {
+          key: 'china',
+          value: 'china',
+          title: 'China',
+          children: [
+            { key: 'beijing', value: 'beijing', title: 'Beijing' },
+            { key: 'shanghai', value: 'shanghai', title: 'Shanghai' },
+            { key: 'guangzhou', value: 'guangzhou', title: 'Guangzhou' },
+          ],
+        },
+        {
+          key: 'japan',
+          value: 'japan',
+          title: 'Japan',
+          children: [
+            { key: 'tokyo', value: 'tokyo', title: 'Tokyo' },
+            { key: 'osaka', value: 'osaka', title: 'Osaka' },
+          ],
+        },
+      ],
+    },
+    {
+      key: 'europe',
+      value: 'europe',
+      title: 'Europe',
+      children: [
+        {
+          key: 'uk',
+          value: 'uk',
+          title: 'United Kingdom',
+          children: [
+            { key: 'london', value: 'london', title: 'London' },
+            { key: 'manchester', value: 'manchester', title: 'Manchester' },
+          ],
+        },
+        {
+          key: 'france',
+          value: 'france',
+          title: 'France',
+          disabled: true,
+          children: [
+            { key: 'paris', value: 'paris', title: 'Paris' },
+            { key: 'lyon', value: 'lyon', title: 'Lyon' },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it('should handle complex tree structure with maxCount correctly', () => {
+    const handleChange = jest.fn();
+    const { getByRole } = render(
+      <TreeSelect
+        treeData={complexTreeData}
+        treeCheckable
+        treeDefaultExpandAll
+        multiple
+        maxCount={3}
+        onChange={handleChange}
+        open
+      />,
+    );
+
+    const container = getByRole('tree');
+
+    // 选择一个顶层节点
+    const asiaNode = within(container).getByText('Asia');
+    fireEvent.click(asiaNode);
+    expect(handleChange).not.toHaveBeenCalled(); // 不应该触发，因为会超过 maxCount
+
+    // 选择叶子节点
+    const beijingNode = within(container).getByText('Beijing');
+    const shanghaiNode = within(container).getByText('Shanghai');
+    const tokyoNode = within(container).getByText('Tokyo');
+    const londonNode = within(container).getByText('London');
+
+    fireEvent.click(beijingNode);
+    fireEvent.click(shanghaiNode);
+    fireEvent.click(tokyoNode);
+    expect(handleChange).toHaveBeenCalledTimes(3);
+
+    // 尝试选择第四个节点，应该被阻止
+    fireEvent.click(londonNode);
+    expect(handleChange).toHaveBeenCalledTimes(3);
+
+    // 验证禁用状态
+    expect(londonNode.closest('div')).toHaveClass('rc-tree-select-tree-treenode-disabled');
+  });
+
+  it('should handle maxCount with mixed selection strategies', () => {
+    const handleChange = jest.fn();
+
+    const { getByRole } = render(
+      <TreeSelect
+        treeData={complexTreeData}
+        treeCheckable
+        treeDefaultExpandAll
+        multiple
+        maxCount={3}
+        onChange={handleChange}
+        defaultValue={['uk']}
+        open
+      />,
+    );
+
+    const container = getByRole('tree');
+
+    const tokyoNode = within(container).getByText('Tokyo');
+    fireEvent.click(tokyoNode);
+
+    // because UK node will show two children, so it will trigger one change
+    expect(handleChange).toHaveBeenCalledTimes(1);
+
+    const beijingNode = within(container).getByText('Beijing');
+    fireEvent.click(beijingNode);
+
+    // should not trigger change
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(beijingNode.closest('div')).toHaveClass('rc-tree-select-tree-treenode-disabled');
+  });
+});

--- a/tests/Select.maxCount.spec.tsx
+++ b/tests/Select.maxCount.spec.tsx
@@ -271,33 +271,6 @@ describe('TreeSelect.maxCount with different strategies', () => {
     fireEvent.click(childCheckboxes[2]);
     expect(handleChange).toHaveBeenCalledTimes(2);
   });
-
-  it('should respect maxCount with SHOW_ALL strategy', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <TreeSelect
-        treeData={treeData}
-        treeCheckable
-        treeDefaultExpandAll
-        multiple
-        maxCount={2}
-        showCheckedStrategy={TreeSelect.SHOW_ALL}
-        onChange={handleChange}
-        open
-      />,
-    );
-
-    // Select parent node - should not work as it would show both parent and children
-    const parentCheckbox = within(container).getByText('parent');
-    fireEvent.click(parentCheckbox);
-    expect(handleChange).not.toHaveBeenCalled();
-
-    // Select individual children
-    const childCheckboxes = within(container).getAllByText(/child/);
-    fireEvent.click(childCheckboxes[0]);
-    fireEvent.click(childCheckboxes[1]);
-    expect(handleChange).toHaveBeenCalledTimes(2);
-  });
 });
 
 describe('TreeSelect.maxCount with treeCheckStrictly', () => {

--- a/tests/Select.warning.spec.js
+++ b/tests/Select.warning.spec.js
@@ -71,4 +71,25 @@ describe('TreeSelect.warning', () => {
       'Warning: Second param of `onDropdownVisibleChange` has been removed.',
     );
   });
+
+  it('warns on using maxCount with showCheckedStrategy=SHOW_ALL when treeCheckStrictly=false', () => {
+    mount(<TreeSelect maxCount={2} showCheckedStrategy="SHOW_ALL" />);
+    expect(spy).toHaveBeenCalledWith(
+      'Warning: `maxCount` not work with `showCheckedStrategy=SHOW_ALL` (when `treeCheckStrictly=false`) or `showCheckedStrategy=SHOW_PARENT`.',
+    );
+  });
+
+  it('warns on using maxCount with showCheckedStrategy=SHOW_PARENT', () => {
+    mount(<TreeSelect maxCount={2} showCheckedStrategy="SHOW_PARENT" />);
+    expect(spy).toHaveBeenCalledWith(
+      'Warning: `maxCount` not work with `showCheckedStrategy=SHOW_ALL` (when `treeCheckStrictly=false`) or `showCheckedStrategy=SHOW_PARENT`.',
+    );
+  });
+
+  it('does not warn on using maxCount with showCheckedStrategy=SHOW_ALL when treeCheckStrictly=true', () => {
+    mount(<TreeSelect maxCount={2} showCheckedStrategy="SHOW_ALL" treeCheckStrictly />);
+    expect(spy).not.toHaveBeenCalledWith(
+      'Warning: `maxCount` not work with `showCheckedStrategy=SHOW_ALL` (when `treeCheckStrictly=false`) or `showCheckedStrategy=SHOW_PARENT`.',
+    );
+  });
 });


### PR DESCRIPTION
# TreeSelect maxCount 功能优化

修复了 TreeSelect 组件在设置 maxCount 时对树形结构处理的问题，使其能够正确处理父子节点关系和树的传导规则。

## 主要改动
- 修复了设置 maxCount 时父节点选择的问题
- 优化了节点禁用状态的计算逻辑，当选中会导致超出 maxCount 限制时正确禁用节点
- 改进了对禁用节点的处理，正确实现树的传导规则
- 根据不同的 showCheckedStrategy 策略准确计算显示值数量

## 具体改进
1. 父节点选中时会考虑其子节点数量，提前禁用可能导致超出 maxCount 的节点
2. 遵循树的传导规则计算可选节点
3. 在节点遍历时正确处理禁用状态
4. 保持已选中节点始终可选
5. 针对不同的显示策略准确计算显示值数量：
   - SHOW_ALL：计算所有选中节点
   - SHOW_CHILD：仅计算叶子节点

## 相关问题
修复了以下场景的问题：
1. 当父节点包含大量子节点时，选中父节点可能导致超出 maxCount 限制
2. 在不同显示策略下，maxCount 的计算不准确
3. 已选中节点被错误禁用的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 在 `TreeSelect` 组件中引入了最大选择数量 (`maxCount`) 和剩余选择数量 (`leftMaxCount`) 属性。
	- 更新了 `OptionList` 组件的节点选择逻辑，增强了对禁用状态的管理。
	- 在示例中新增了禁用节点的支持。
	- 新增了针对复杂树结构的测试用例，以验证最大选择数量的处理。
	- 添加了警告机制，以提示不兼容的选中策略和最大选择数量设置。

- **bug 修复**
	- 改进了选项选择逻辑，以确保在多选模式下不会超过最大选择数量。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->