### PR TITLE
fix: force update to keep disable state work

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -161,7 +161,7 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
 
   // ========================= Disabled =========================
   // Cache disabled states in React state to ensure re-render when cache updates
-  const [disabledCache, setDisabledCache] = React.useState<Map<string, boolean>>(new Map());
+  const [disabledCache, setDisabledCache] = React.useState<Map<string, boolean>>(() => new Map());
 
   React.useEffect(() => {
     if (leftMaxCount) {
@@ -184,13 +184,9 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
         );
 
         const checkableChildrenCount = checkableChildren.length;
-        const newCache = new Map(disabledCache);
-        newCache.set(value, checkableChildrenCount > leftMaxCount);
-        setDisabledCache(newCache);
+        disabledCache.set(value, checkableChildrenCount > leftMaxCount);
       } else {
-        const newCache = new Map(disabledCache);
-        newCache.set(value, false);
-        setDisabledCache(newCache);
+        disabledCache.set(value, false);
       }
     }
     return disabledCache.get(value);

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -162,10 +162,18 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
   // ========================= Disabled =========================
   const disabledCacheRef = React.useRef<Map<string, boolean>>(new Map());
 
-  // Clear cache if `leftMaxCount` changed
+  // Force update is needed since clearing cache alone doesn't trigger
+  // a recalculation of node disabled states
+  const [, setForceUpdate] = React.useState({});
+
+  // When leftMaxCount changes, we need to:
+  // 1. Clear the disabled state cache
+  // 2. Trigger a re-render to recalculate all node disabled states
+  // This ensures parent nodes are properly disabled when max count is reached
   React.useEffect(() => {
     if (leftMaxCount) {
       disabledCacheRef.current.clear();
+      setForceUpdate({});
     }
   }, [leftMaxCount]);
 


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/pull/51759#issuecomment-2560896013

强制re-render一下，处理缓存重置后状态不同步的问题，这么做会导致多一次渲染，对性能可能有点影响。或许还有更好的解法（

效果：
![249A75CD-0D38-4FC0-A2B2-B93EF07C3DB6](https://github.com/user-attachments/assets/147d33c2-b295-466e-afae-d7943e86b66b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 改进了 `OptionList` 组件对禁用状态的管理，使其更加响应式。
- **修复**
	- 优化了禁用状态缓存的清理逻辑，确保状态更新时能够正确触发重新渲染。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->