### PR TITLE
feat: combine search props

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "classnames": "2.x",
-    "@rc-component/select": "~1.0.7",
+    "@rc-component/select": "~1.1.0",
     "@rc-component/tree": "~1.0.1",
     "@rc-component/util": "^1.2.1"
   },

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -40,8 +40,6 @@ export type SemanticName = 'input' | 'prefix' | 'suffix';
 export type PopupSemantic = 'item' | 'itemTitle';
 export interface SearchConfig {
   searchValue?: string;
-  /** @deprecated Use `searchValue` instead */
-  inputValue?: string;
   onSearch?: (value: string) => void;
   autoClearSearchValue?: boolean;
   filterTreeNode?: boolean | ((inputValue: string, treeNode: DataNode) => boolean);
@@ -207,7 +205,6 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
   const [mergedShowSearch, searchConfig] = useSearchConfig(showSearch, props);
   const {
     searchValue,
-    inputValue,
     onSearch,
     autoClearSearchValue = true,
     filterTreeNode,
@@ -240,7 +237,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
 
   // =========================== Search ===========================
   const [mergedSearchValue, setSearchValue] = useMergedState('', {
-    value: searchValue !== undefined ? searchValue : inputValue,
+    value: searchValue,
     postState: search => search || '',
   });
 

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -65,7 +65,7 @@ export interface TreeSelectProps<ValueType = any, OptionType extends DataNode = 
   showSearch?: boolean | SearchConfig;
   /** @deprecated Use `showSearch.searchValue` instead */
   searchValue?: string;
-  /** @deprecated Use `searchValue` instead */
+  /** @deprecated Use `showSearch.searchValue` instead */
   inputValue?: string;
   /** @deprecated Use `showSearch.onSearch` instead */
   onSearch?: (value: string) => void;

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -34,10 +34,11 @@ import type {
   FieldNames,
   LegacyDataNode,
 } from './interface';
+import useSearchConfig from './hooks/useSearchConfig';
 
 export type SemanticName = 'input' | 'prefix' | 'suffix';
 export type PopupSemantic = 'item' | 'itemTitle';
-interface SearchConfig {
+export interface SearchConfig {
   searchValue?: string;
   /** @deprecated Use `searchValue` instead */
   inputValue?: string;
@@ -203,19 +204,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
   const mergedLabelInValue = treeCheckStrictly || labelInValue;
   const mergedMultiple = mergedCheckable || multiple;
 
-  const legacySearchProps = [
-    'searchValue',
-    'inputValue',
-    'onSearch',
-    'autoClearSearchValue',
-    'filterTreeNode',
-    'treeNodeFilterProp',
-  ];
-  const legacyShowSearch: SearchConfig = {};
-  legacySearchProps.forEach(propsName => {
-    legacyShowSearch[propsName] = props?.[propsName];
-  });
-  const mergedShowSearch = typeof showSearch === 'object' ? showSearch : legacyShowSearch;
+  const [mergedShowSearch, searchConfig] = useSearchConfig(showSearch, props);
   const {
     searchValue,
     inputValue,
@@ -223,7 +212,7 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
     autoClearSearchValue = true,
     filterTreeNode,
     treeNodeFilterProp = 'value',
-  } = mergedShowSearch;
+  } = searchConfig;
 
   const [internalValue, setInternalValue] = useMergedState(defaultValue, { value });
 
@@ -757,8 +746,8 @@ const TreeSelect = React.forwardRef<BaseSelectRef, TreeSelectProps>((props, ref)
           displayValues={cachedDisplayValues}
           onDisplayValuesChange={onDisplayValuesChange}
           // >>> Search
-          {...mergedShowSearch}
-          showSearch={showSearch === undefined ? undefined : !!showSearch}
+          {...searchConfig}
+          showSearch={mergedShowSearch}
           searchValue={mergedSearchValue}
           onSearch={onInternalSearch}
           // >>> Options

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -1,14 +1,11 @@
-import type { SearchConfig } from '@/TreeSelect';
+import type { SearchConfig, TreeSelectProps } from '@/TreeSelect';
 import * as React from 'react';
-const legacySearchProps = [
-  'searchValue',
-  'onSearch',
-  'autoClearSearchValue',
-  'filterTreeNode',
-  'treeNodeFilterProp',
-];
+
 // Convert `showSearch` to unique config
-export default function useSearchConfig(showSearch: boolean | SearchConfig, props: any) {
+export default function useSearchConfig(
+  showSearch: boolean | SearchConfig,
+  props: TreeSelectProps,
+) {
   const {
     searchValue,
     inputValue,
@@ -18,24 +15,27 @@ export default function useSearchConfig(showSearch: boolean | SearchConfig, prop
     treeNodeFilterProp,
   } = props;
   return React.useMemo<[boolean | undefined, SearchConfig]>(() => {
-    const legacyShowSearch: SearchConfig = {};
-    legacySearchProps.forEach(name => {
-      const val = props?.[name];
-      if (val !== undefined) {
-        legacyShowSearch[name] = val;
-      }
-      if (name === 'searchValue') {
-        legacyShowSearch[name] = val ?? props?.inputValue;
-      }
-    });
-    const searchConfig: SearchConfig =
-      typeof showSearch === 'object' ? showSearch : legacyShowSearch;
-    if (showSearch === undefined) {
-      return [undefined, searchConfig];
+    const legacysearchConfig: SearchConfig = {
+      searchValue: searchValue ?? inputValue,
+      onSearch,
+      autoClearSearchValue,
+      filterTreeNode,
+      treeNodeFilterProp,
+    };
+
+    if (showSearch === undefined || showSearch === true) {
+      return [showSearch as boolean, legacysearchConfig];
     }
+
     if (!showSearch) {
       return [false, {}];
     }
+
+    const searchConfig = {
+      ...legacysearchConfig,
+      ...showSearch,
+    };
+
     return [true, searchConfig];
   }, [
     showSearch,

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -15,26 +15,21 @@ export default function useSearchConfig(
     treeNodeFilterProp,
   } = props;
   return React.useMemo<[boolean | undefined, SearchConfig]>(() => {
-    const legacysearchConfig: SearchConfig = {
+    const searchConfig: SearchConfig = {
       searchValue: searchValue ?? inputValue,
       onSearch,
       autoClearSearchValue,
       filterTreeNode,
       treeNodeFilterProp,
+      ...(typeof showSearch === 'object' ? showSearch : {}),
     };
-
-    if (showSearch === undefined || showSearch === true) {
-      return [showSearch as boolean, legacysearchConfig];
-    }
-
-    if (!showSearch) {
+    if (showSearch === false) {
       return [false, {}];
     }
 
-    const searchConfig = {
-      ...legacysearchConfig,
-      ...showSearch,
-    };
+    if (showSearch === undefined) {
+      return [undefined, searchConfig];
+    }
 
     return [true, searchConfig];
   }, [

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -1,0 +1,38 @@
+import type { SearchConfig } from '@/TreeSelect';
+import * as React from 'react';
+const legacySearchProps = [
+  'searchValue',
+  'inputValue',
+  'onSearch',
+  'autoClearSearchValue',
+  'filterTreeNode',
+  'treeNodeFilterProp',
+];
+// Convert `showSearch` to unique config
+export default function useSearchConfig(showSearch, props) {
+  return React.useMemo<[boolean, SearchConfig]>(() => {
+    const legacyShowSearch: SearchConfig = {};
+    legacySearchProps.forEach(propsName => {
+      legacyShowSearch[propsName] = props?.[propsName];
+    });
+    const searchConfig: SearchConfig =
+      typeof showSearch === 'object' ? showSearch : legacyShowSearch;
+    if (showSearch === undefined) {
+      return [undefined, searchConfig];
+    }
+    if (!showSearch) {
+      return [false, {}];
+    }
+    return [true, searchConfig];
+  }, [
+    showSearch,
+    props?.filterOption,
+    props?.searchValue,
+    props?.optionFilterProp,
+    props?.optionLabelProp,
+    props?.filterSort,
+    props?.onSearch,
+    props?.autoClearSearchValue,
+    props?.tokenSeparators,
+  ]);
+}

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -9,11 +9,20 @@ const legacySearchProps = [
   'treeNodeFilterProp',
 ];
 // Convert `showSearch` to unique config
-export default function useSearchConfig(showSearch, props) {
+export default function useSearchConfig(showSearch: boolean | SearchConfig, props: any) {
+  const {
+    searchValue,
+    inputValue,
+    onSearch,
+    autoClearSearchValue,
+    filterTreeNode,
+    treeNodeFilterProp,
+  } = props;
   return React.useMemo<[boolean, SearchConfig]>(() => {
     const legacyShowSearch: SearchConfig = {};
-    legacySearchProps.forEach(propsName => {
-      legacyShowSearch[propsName] = props?.[propsName];
+    legacySearchProps.forEach(name => {
+      const val = props?.[name];
+      if (val !== undefined) legacyShowSearch[name] = val;
     });
     const searchConfig: SearchConfig =
       typeof showSearch === 'object' ? showSearch : legacyShowSearch;
@@ -26,11 +35,11 @@ export default function useSearchConfig(showSearch, props) {
     return [true, searchConfig];
   }, [
     showSearch,
-    props?.searchValue,
-    props?.inputValue,
-    props?.onSearch,
-    props?.autoClearSearchValue,
-    props?.filterTreeNode,
-    props?.treeNodeFilterProp,
+    searchValue,
+    inputValue,
+    onSearch,
+    autoClearSearchValue,
+    filterTreeNode,
+    treeNodeFilterProp,
   ]);
 }

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -15,23 +15,18 @@ export default function useSearchConfig(
     treeNodeFilterProp,
   } = props;
   return React.useMemo<[boolean | undefined, SearchConfig]>(() => {
+    const isObject = typeof showSearch === 'object';
+
     const searchConfig: SearchConfig = {
       searchValue: searchValue ?? inputValue,
       onSearch,
       autoClearSearchValue,
       filterTreeNode,
       treeNodeFilterProp,
-      ...(typeof showSearch === 'object' ? showSearch : {}),
+      ...(isObject ? showSearch : {}),
     };
-    if (showSearch === false) {
-      return [false, {}];
-    }
 
-    if (showSearch === undefined) {
-      return [undefined, searchConfig];
-    }
-
-    return [true, searchConfig];
+    return [isObject ? true : showSearch, searchConfig];
   }, [
     showSearch,
     searchValue,

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -2,7 +2,6 @@ import type { SearchConfig } from '@/TreeSelect';
 import * as React from 'react';
 const legacySearchProps = [
   'searchValue',
-  'inputValue',
   'onSearch',
   'autoClearSearchValue',
   'filterTreeNode',
@@ -22,7 +21,12 @@ export default function useSearchConfig(showSearch: boolean | SearchConfig, prop
     const legacyShowSearch: SearchConfig = {};
     legacySearchProps.forEach(name => {
       const val = props?.[name];
-      if (val !== undefined) legacyShowSearch[name] = val;
+      if (val !== undefined) {
+        legacyShowSearch[name] = val;
+      }
+      if (name === 'searchValue') {
+        legacyShowSearch[name] = val ?? props?.inputValue;
+      }
     });
     const searchConfig: SearchConfig =
       typeof showSearch === 'object' ? showSearch : legacyShowSearch;

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -26,13 +26,11 @@ export default function useSearchConfig(showSearch, props) {
     return [true, searchConfig];
   }, [
     showSearch,
-    props?.filterOption,
     props?.searchValue,
-    props?.optionFilterProp,
-    props?.optionLabelProp,
-    props?.filterSort,
+    props?.inputValue,
     props?.onSearch,
     props?.autoClearSearchValue,
-    props?.tokenSeparators,
+    props?.filterTreeNode,
+    props?.treeNodeFilterProp,
   ]);
 }

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -17,7 +17,7 @@ export default function useSearchConfig(showSearch: boolean | SearchConfig, prop
     filterTreeNode,
     treeNodeFilterProp,
   } = props;
-  return React.useMemo<[boolean, SearchConfig]>(() => {
+  return React.useMemo<[boolean | undefined, SearchConfig]>(() => {
     const legacyShowSearch: SearchConfig = {};
     legacySearchProps.forEach(name => {
       const val = props?.[name];

--- a/tests/Select.spec.tsx
+++ b/tests/Select.spec.tsx
@@ -835,5 +835,21 @@ describe('TreeSelect.basic', () => {
 
       expect(options).toHaveLength(4);
     });
+    it.only.each([
+      // [description, props, shouldExist]
+      ['showSearch=false ', { showSearch: false }, false],
+      ['showSearch=undefined ', {}, false],
+      ['showSearch=true', { showSearch: true }, true],
+    ])('%s', (_, props: { showSearch?: boolean; mode?: 'tags' }, shouldExist) => {
+      const { container } = render(
+        <TreeSelect open treeDefaultExpandAll treeData={treeData} {...props} />,
+      );
+      const inputNode = container.querySelector('input');
+      if (shouldExist) {
+        expect(inputNode).not.toHaveAttribute('readonly');
+      } else {
+        expect(inputNode).toHaveAttribute('readonly');
+      }
+    });
   });
 });

--- a/tests/Select.spec.tsx
+++ b/tests/Select.spec.tsx
@@ -835,7 +835,7 @@ describe('TreeSelect.basic', () => {
 
       expect(options).toHaveLength(4);
     });
-    it.only.each([
+    it.each([
       // [description, props, shouldExist]
       ['showSearch=false ', { showSearch: false }, false],
       ['showSearch=undefined ', {}, false],


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/33482
FRC: https://github.com/ant-design/ant-design/discussions/53978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持通过 showSearch 配置对象统一设置搜索相关属性，简化 TreeSelect 组件的搜索配置方式。
  - 新增 useSearchConfig Hook，用于统一处理搜索配置，提升性能和可维护性。

- **重构**
  - 将原有多个搜索相关属性合并为 showSearch 配置项，原有属性已标记为废弃但仍保持兼容。

- **测试**
  - 新增用例，验证 showSearch 配置对象与旧用法在搜索、过滤等场景下的兼容性和一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->