### PR TITLE
fix: restore load switcher after clearing search

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -326,8 +326,7 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
 
   const hasLoadDataFn = useMemo(
     () => (searchValue ? false : true),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [searchValue, treeExpandedKeys || expandedKeys],
+    [searchValue],
     ([preSearchValue], [nextSearchValue]) => preSearchValue !== nextSearchValue,
   );
 

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -138,8 +138,21 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     if (treeExpandedKeys) {
       return [...treeExpandedKeys];
     }
-    return searchValue ? searchExpandedKeys : expandedKeys;
-  }, [expandedKeys, searchExpandedKeys, treeExpandedKeys, searchValue]);
+    if (searchValue) {
+      return searchExpandedKeys;
+    }
+    if (searchExpandedKeys && loadData && !treeDefaultExpandAll) {
+      return expandedKeys || [];
+    }
+    return expandedKeys;
+  }, [
+    expandedKeys,
+    searchExpandedKeys,
+    treeExpandedKeys,
+    searchValue,
+    loadData,
+    treeDefaultExpandAll,
+  ]);
 
   const onInternalExpand = (keys: Key[]) => {
     setExpandedKeys(keys);
@@ -315,8 +328,7 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
     () => (searchValue ? false : true),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [searchValue, treeExpandedKeys || expandedKeys],
-    ([preSearchValue], [nextSearchValue, nextExcludeSearchExpandedKeys]) =>
-      preSearchValue !== nextSearchValue && !!(nextSearchValue || nextExcludeSearchExpandedKeys),
+    ([preSearchValue], [nextSearchValue]) => preSearchValue !== nextSearchValue,
   );
 
   const syncLoadData = hasLoadDataFn ? loadData : null;

--- a/tests/Select.loadData.spec.tsx
+++ b/tests/Select.loadData.spec.tsx
@@ -43,4 +43,28 @@ describe('TreeSelect.loadData', () => {
       ).toHaveLength(2 + i);
     }
   });
+
+  it('keeps load switcher after clearing search value', () => {
+    const loadData = jest.fn(() => Promise.resolve());
+    const { container } = render(
+      <TreeSelect
+        open
+        showSearch
+        treeDataSimpleMode
+        loadData={loadData}
+        treeData={[{ id: 1, pId: 0, value: '1', title: 'Parent' }]}
+      />,
+    );
+
+    const input = container.querySelector('input')!;
+
+    expect(container.querySelector('.rc-tree-select-tree-switcher_close')).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: '1' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(loadData).not.toHaveBeenCalled();
+    expect(container.querySelector('.rc-tree-select-tree-switcher_close')).toBeTruthy();
+    expect(container.querySelector('.rc-tree-select-tree-switcher-noop')).toBeFalsy();
+  });
 });

--- a/tests/Select.loadData.spec.tsx
+++ b/tests/Select.loadData.spec.tsx
@@ -44,7 +44,7 @@ describe('TreeSelect.loadData', () => {
     }
   });
 
-  it('keeps load switcher after clearing search value', () => {
+  it('keeps load switcher after clearing search value', async () => {
     const loadData = jest.fn(() => Promise.resolve());
     const { container } = render(
       <TreeSelect
@@ -66,5 +66,12 @@ describe('TreeSelect.loadData', () => {
     expect(loadData).not.toHaveBeenCalled();
     expect(container.querySelector('.rc-tree-select-tree-switcher_close')).toBeTruthy();
     expect(container.querySelector('.rc-tree-select-tree-switcher-noop')).toBeFalsy();
+
+    fireEvent.click(container.querySelector('.rc-tree-select-tree-switcher_close')!);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(loadData).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
修复 ant-design 中反馈的 TreeSelect 异步加载问题：https://github.com/ant-design/ant-design/issues/55675

当用户在 TreeSelect 中搜索后再清空搜索内容时，异步节点仍然会被渲染成 noop switcher，导致原本用于展开/触发 `loadData` 的入口没有恢复，用户无法继续加载该节点。

这个修改会在清空搜索后恢复异步节点正常的加载/展开 switcher，同时保持搜索过程中不触发 `loadData` 的现有行为。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* 修复了搜索值清空后树展开及数据加载器状态保持不正确的问题，确保在清空搜索后树的展开状态能正确恢复。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->