### PR TITLE
chore: bump select to 1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rc-component/tree-select",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "tree-select ui component for react",
   "keywords": [
     "react",
@@ -43,7 +43,7 @@
     "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@rc-component/select": "~1.8.0",
+    "@rc-component/select": "~1.9.0",
     "@rc-component/tree": "~1.3.2",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"

--- a/tests/Select.checkable.spec.tsx
+++ b/tests/Select.checkable.spec.tsx
@@ -242,9 +242,9 @@ describe('TreeSelect.checkable', () => {
     selectNode(0);
     search(container, 'foo');
 
-    // Clear all using mouseDown (same as wrapper.clearAll())
+    // Clear all using click (same as wrapper.clearAll())
     const clearButton = container.querySelector('.rc-tree-select-clear')!;
-    fireEvent.mouseDown(clearButton);
+    fireEvent.click(clearButton);
 
     // Check that no items are selected
     expect(container.querySelectorAll('.rc-tree-select-selection-item')).toHaveLength(0);

--- a/tests/__snapshots__/Select.checkable.spec.tsx.snap
+++ b/tests/__snapshots__/Select.checkable.spec.tsx.snap
@@ -288,7 +288,6 @@ exports[`TreeSelect.checkable uncheck remove by selector not treeCheckStrictly 2
       >
         <div
           class="rc-tree-select-placeholder"
-          style="visibility: visible;"
         />
       </div>
       <div
@@ -776,7 +775,6 @@ exports[`TreeSelect.checkable uncheck remove by tree check 2`] = `
       >
         <div
           class="rc-tree-select-placeholder"
-          style="visibility: visible;"
         />
       </div>
       <div

--- a/tests/__snapshots__/Select.multiple.spec.js.snap
+++ b/tests/__snapshots__/Select.multiple.spec.js.snap
@@ -13,7 +13,6 @@ exports[`TreeSelect.multiple can hide search box by showSearch = false 1`] = `
     >
       <div
         class="rc-tree-select-placeholder"
-        style="visibility: visible;"
       />
     </div>
     <div

--- a/tests/__snapshots__/Select.spec.tsx.snap
+++ b/tests/__snapshots__/Select.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`TreeSelect.basic render renders TreeNode correctly 1`] = `
   >
     <div
       class="rc-tree-select-placeholder"
-      style="visibility: visible;"
     />
     <input
       aria-autocomplete="list"
@@ -38,7 +37,6 @@ exports[`TreeSelect.basic render renders TreeNode correctly with falsy child 1`]
   >
     <div
       class="rc-tree-select-placeholder"
-      style="visibility: visible;"
     />
     <input
       aria-autocomplete="list"
@@ -72,7 +70,6 @@ exports[`TreeSelect.basic render renders correctly 1`] = `
     >
       <div
         class="awesome-placeholder"
-        style="visibility: visible;"
       />
     </div>
     <div
@@ -106,7 +103,6 @@ exports[`TreeSelect.basic render renders disabled correctly 1`] = `
   >
     <div
       class="rc-tree-select-placeholder"
-      style="visibility: visible;"
     />
     <input
       aria-autocomplete="list"
@@ -139,7 +135,6 @@ exports[`TreeSelect.basic render renders tree correctly 1`] = `
       >
         <div
           class="rc-tree-select-placeholder"
-          style="visibility: visible;"
         />
       </div>
       <div
@@ -381,7 +376,6 @@ exports[`TreeSelect.basic render renders treeDataSimpleMode correctly 1`] = `
     >
       <div
         class="rc-tree-select-placeholder"
-        style="visibility: visible;"
       />
       <input
         aria-autocomplete="list"
@@ -636,7 +630,7 @@ exports[`TreeSelect.basic search nodes check tree changed by filter 2`] = `
     >
       <div
         class="rc-tree-select-placeholder"
-        style="visibility: visible;"
+        style=""
       />
       <input
         aria-autocomplete="list"
@@ -913,7 +907,6 @@ exports[`TreeSelect.basic search nodes renders search input 1`] = `
   >
     <div
       class="rc-tree-select-placeholder"
-      style="visibility: visible;"
     />
     <input
       aria-autocomplete="list"

--- a/tests/util.tsx
+++ b/tests/util.tsx
@@ -62,7 +62,7 @@ export function clearSelection(element: HTMLElement, index = 0) {
 }
 
 export function clearAll(element: HTMLElement) {
-  fireEvent.mouseDown(element.querySelector('.rc-tree-select-clear')!);
+  fireEvent.click(element.querySelector('.rc-tree-select-clear')!);
 }
 
 export function getSelections(element: HTMLElement = document.body) {


### PR DESCRIPTION
## Summary
- bump `@rc-component/tree-select` to `1.12.0`
- update `@rc-component/select` dependency range to `~1.9.0`
- align clear interaction tests and snapshots with `@rc-component/select@1.9`

## Test
- `ut run lint`
- `ut run tsc`
- `ut test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 升级项目版本至 **1.12.0**。
  * 更新了一个核心依赖版本。

* **Tests**
  * 调整了清空相关测试的触发方式，与实际交互保持一致。
  * 更新了辅助清空操作的测试实现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->