### PR TITLE
fix(TreeSelect): preserve disabled child selection

### DIFF
--- a/src/utils/strategyUtil.ts
+++ b/src/utils/strategyUtil.ts
@@ -33,7 +33,12 @@ export function formatStrategyValues(
     return values.filter(key => {
       const entity = keyEntities[key];
       const parent = entity ? entity.parent : null;
-      return !parent || isCheckDisabled(parent.node) || !valueSet.has(parent.key as SafeKey);
+      return (
+        !parent ||
+        isCheckDisabled(entity.node) ||
+        isCheckDisabled(parent.node) ||
+        !valueSet.has(parent.key as SafeKey)
+      );
     });
   }
   return values;

--- a/tests/Select.checkable.spec.tsx
+++ b/tests/Select.checkable.spec.tsx
@@ -789,6 +789,71 @@ describe('TreeSelect.checkable', () => {
     expect(document.querySelector('.rc-tree-select-tree-treenode-checkbox-checked')).toBeTruthy();
   });
 
+  it('should keep disabled child selected when checking its parent', () => {
+    const treeData = [
+      {
+        title: 'Node1',
+        value: '0-0',
+        key: '0-0',
+        children: [
+          {
+            title: 'Child Node1',
+            value: '0-0-0',
+            key: '0-0-0',
+          },
+        ],
+      },
+      {
+        title: 'Node2',
+        value: '0-1',
+        key: '0-1',
+        children: [
+          {
+            title: 'Child Node3',
+            value: '0-1-0',
+            key: '0-1-0',
+            disabled: true,
+          },
+          {
+            title: 'Child Node4',
+            value: '0-1-1',
+            key: '0-1-1',
+          },
+          {
+            title: 'Child Node5',
+            value: '0-1-2',
+            key: '0-1-2',
+          },
+        ],
+      },
+    ];
+
+    const App = () => {
+      const [value, setValue] = React.useState(['0-1-0']);
+
+      return (
+        <TreeSelect
+          open
+          treeCheckable
+          treeDefaultExpandAll
+          showCheckedStrategy={SHOW_PARENT}
+          value={value}
+          onChange={setValue}
+          treeData={treeData}
+        />
+      );
+    };
+
+    const { container } = render(<App />);
+
+    selectNode(2);
+
+    expect(getSelections(container)).toHaveLength(2);
+    expect([getSelectionText(container, 0), getSelectionText(container, 1)]).toEqual(
+      expect.arrayContaining(['Node2', 'Child Node3']),
+    );
+  });
+
   // https://github.com/ant-design/ant-design/issues/32184
   it('should pass correct keys', () => {
     const { rerender } = render(


### PR DESCRIPTION
## Summary

- preserve selected disabled child nodes when their parent is checked with `SHOW_PARENT`
- add a controlled TreeSelect regression test for the disabled-child scenario

## Root cause

`SHOW_PARENT` filtered every child whose parent was selected without considering whether the child itself was disabled. In a controlled TreeSelect, the emitted value therefore dropped the disabled child and cleared its selection on the next render.

## Validation

- `ut test --runInBand` (184 tests passed)
- `ut tsc`
- `ut lint` (0 errors; 6 existing warnings)

Related to ant-design/ant-design#16096


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化 `SHOW_PARENT` 选择策略：勾选父节点时，已选中的禁用子节点会继续保留。
  - 受控 `TreeSelect` 中将同时正确显示父节点及其禁用子节点，避免已选内容意外丢失。

- **测试**
  - 新增相关场景测试，覆盖父节点选择与禁用子节点保留行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->