### PR TITLE
chore(deps): upgrade @rc-component/select to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@rc-component/select": "~1.10.0",
+    "@rc-component/select": "~1.11.0",
     "@rc-component/tree": "~1.5.0",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"


### PR DESCRIPTION
Upgrade `@rc-component/select` from `~1.10.0` to `~1.11.0` to consume the virtual option accessibility improvements from react-component/select#1226.

Validation:
- `ut run test -- --runInBand`
- `ut run tsc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **依赖更新**
  * 更新选择组件依赖版本，提升兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->