### PR TITLE
fix: search children of disabled tree nodes

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -225,16 +225,16 @@ const OptionList: React.ForwardRefRenderFunction<ReviseRefOptionListProps> = (_,
   // ========================== Get First Selectable Node ==========================
   const getFirstMatchingNode = (nodes: EventDataNode<any>[]): EventDataNode<any> | null => {
     for (const node of nodes) {
-      if (node.disabled || node.selectable === false) {
-        continue;
-      }
+      const isNodeSelectable = !node.disabled && node.selectable !== false;
 
-      if (searchValue) {
-        if (filterTreeNode(node)) {
+      if (isNodeSelectable) {
+        if (searchValue) {
+          if (filterTreeNode(node)) {
+            return node;
+          }
+        } else {
           return node;
         }
-      } else {
-        return node;
       }
 
       if (node[fieldNames.children]) {

--- a/tests/Select.SearchInput.spec.js
+++ b/tests/Select.SearchInput.spec.js
@@ -193,6 +193,39 @@ describe('TreeSelect.SearchInput', () => {
   });
 
   describe('keyboard events', () => {
+    it.each([
+      ['disabled', { disabled: true }],
+      ['non-selectable', { selectable: false }],
+    ])('should search selectable children of a %s parent', (_, parentProps) => {
+      const onSelect = jest.fn();
+      const { getByRole, container } = render(
+        <TreeSelect
+          showSearch
+          open
+          virtual={false}
+          onSelect={onSelect}
+          treeData={[
+            {
+              value: 'parent',
+              label: 'Parent',
+              ...parentProps,
+              children: [{ value: 'child', label: 'Matching child' }],
+            },
+          ]}
+        />,
+      );
+
+      const input = getByRole('combobox');
+      fireEvent.change(input, { target: { value: 'child' } });
+
+      expect(container.querySelector('.rc-tree-select-tree-treenode-active')).toHaveTextContent(
+        'Matching child',
+      );
+
+      fireEvent.keyDown(input, { keyCode: KeyCode.ENTER });
+      expect(onSelect).toHaveBeenCalledWith('child', expect.anything());
+    });
+
     it('should select first matched node when press enter', () => {
       const onSelect = jest.fn();
       const { getByRole } = render(


### PR DESCRIPTION
## Summary

- keep traversing children when a tree node is disabled or `selectable={false}`
- activate the first matching selectable descendant during search
- cover keyboard selection below both disabled and non-selectable parents

Fixes #652.

## Why

`getFirstMatchingNode` previously used `continue` for a disabled or non-selectable node. That skipped the node's entire subtree, so an enabled matching child could be rendered in search results without becoming active or selectable through Enter.

The updated traversal only excludes the parent itself as a candidate. It still descends into the parent's children, while the existing Enter handler continues to enforce disabled and selectable guards on the active node.

## Verification

- Exact-base regression: both new cases failed because no active node was found
- Focused search-input suite: 10/10 tests passed
- Full suite: 12/12 suites, 186/186 tests, 15/15 snapshots passed
- `npm run tsc`
- `npm run lint` (0 errors; 6 existing warnings)
- `npm run compile`
- `git diff --check`

AI assistance disclosure: Codex was used to trace the active-node traversal, construct the exact-base regressions, implement the focused fix, and run the verification commands. I reviewed and verified the source diff, failure reproduction, and test results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复搜索结果选择逻辑：即使父节点被禁用或不可选择，仍可搜索并选中其可选择的子节点。
  - 优化树形选项的匹配行为，避免不必要地跳过整个子树。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->