### PR TITLE
fix: preserve numeric zero tree keys

### DIFF
--- a/src/hooks/useDataEntities.ts
+++ b/src/hooks/useDataEntities.ts
@@ -27,7 +27,7 @@ export default (treeData: any, fieldNames: FieldNames) =>
           warning(!isNil(val), 'TreeNode `value` is invalidate: undefined');
           warning(!wrapper.valueEntities.has(val), `Same \`value\` exist in the tree: ${val}`);
           warning(
-            !key || String(key) === String(val),
+            isNil(key) || String(key) === String(val),
             `\`key\` or \`value\` with TreeNode must be the same or you can remove one of them. key: ${key}, value: ${val}.`,
           );
         }

--- a/src/hooks/useTreeData.ts
+++ b/src/hooks/useTreeData.ts
@@ -9,7 +9,7 @@ function buildTreeStructure(nodes: DataNode[], config: SimpleModeConfig): DataNo
 
   nodes.forEach(node => {
     const nodeKey = node[id];
-    const clonedNode = { ...node, key: node.key || nodeKey };
+    const clonedNode = { ...node, key: node.key ?? nodeKey };
     nodeMap.set(nodeKey, clonedNode);
   });
 

--- a/tests/Select.spec.tsx
+++ b/tests/Select.spec.tsx
@@ -139,6 +139,21 @@ describe('TreeSelect.basic', () => {
       );
       expect(container.firstChild).toMatchSnapshot();
     });
+
+    it('preserves a numeric zero key in treeDataSimpleMode', () => {
+      const onSelect = jest.fn();
+      const { container } = render(
+        <TreeSelect
+          treeData={[{ id: 'fallback', key: 0, value: 0, title: 'zero' }]}
+          treeDataSimpleMode
+          onSelect={onSelect}
+          open
+        />,
+      );
+
+      fireEvent.click(container.querySelector('.rc-tree-select-tree-node-content-wrapper'));
+      expect(onSelect).toHaveBeenCalledWith(0, expect.objectContaining({ key: 0 }));
+    });
   });
 
   it('sets default value', () => {

--- a/tests/Select.tree.spec.js
+++ b/tests/Select.tree.spec.js
@@ -87,6 +87,16 @@ describe('TreeSelect.tree', () => {
     spy.mockRestore();
   });
 
+  it('warning if numeric zero key is not same as value', () => {
+    resetWarned();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(<TreeSelect treeData={[{ title: 'zero', value: 'different', key: 0 }]} />);
+    expect(spy).toHaveBeenCalledWith(
+      'Warning: `key` or `value` with TreeNode must be the same or you can remove one of them. key: 0, value: different.',
+    );
+    spy.mockRestore();
+  });
+
   it('warning if node undefined value', () => {
     resetWarned();
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Summary

- preserve an explicit numeric `key: 0` when normalizing simple-mode tree data
- validate `key: 0` against its value instead of treating it as absent
- cover the public `onSelect` option and warning paths

## Why

`DataNode.key` is a `React.Key`, so numeric zero is valid. The simple-mode normalizer used `node.key || nodeKey`, which replaced `0` with the configured id. Selecting that node then returned the substituted id in the public option object instead of the caller's original key.

The development warning had the parallel `!key` check, so a provided zero key also bypassed the existing key/value consistency warning. Both sites now distinguish only `null` and `undefined` from real keys.

## Exact-base regressions

On the base commit:

- selecting `{ id: "fallback", key: 0, value: 0 }` called `onSelect(0, { key: "fallback", ... })` instead of preserving `key: 0`;
- `{ key: 0, value: "different" }` produced no consistency warning.

Both regressions pass with the fix.

## Validation

- `npm test -- --runInBand` (12 suites, 186 tests, 15 snapshots)
- `npm run tsc`
- `npm run lint` (0 errors; 6 pre-existing warnings)
- focused Prettier check on all changed source and tests
- `npm run compile` (ESM, CJS, declarations)
- `git diff --check`

## Overlap audit

No current open PR implements numeric-zero key handling. The old #392 also lists `useTreeData.ts`, but its diff targets the pre-refactor null-children formatter and has no semantic overlap with key normalization.

AI assistance disclosure: Codex was used to trace the simple-mode normalization and callback path, audit open PR files and history, and draft the regressions. The exact-base failures and complete fixed suite were run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复树节点键值为 `0` 或空字符串时被错误替换的问题。
  * 改进键值校验，确保仅在键值为 `null` 或 `undefined` 时触发警告。
  * 保留数值键 `0`，确保节点选择操作返回正确的键值。

* **Tests**
  * 增加相关回归测试，覆盖数值键及键值不一致场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->