### PR TITLE
chore(deps): upgrade @rc-component/tree to 1.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@rc-component/select": "~1.11.0",
-    "@rc-component/tree": "~1.5.0",
+    "@rc-component/tree": "~1.5.3",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },

--- a/tests/Select.spec.tsx
+++ b/tests/Select.spec.tsx
@@ -11,6 +11,7 @@ import {
   getVisibleTreeNodes,
   keyDown,
   keyUp,
+  search,
   selectNode,
   triggerOpen,
 } from './util';
@@ -259,6 +260,36 @@ describe('TreeSelect.basic', () => {
       expect(container.firstChild).toMatchSnapshot();
       rerender(<Wrapper searchValue="" treeDefaultExpandAll open />);
       expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('collapses search-expanded branches when search is cleared', () => {
+      const { container } = render(
+        <TreeSelect
+          open
+          showSearch={{ treeNodeFilterProp: 'title' }}
+          treeData={[
+            {
+              key: 'parent',
+              value: 'parent',
+              title: 'Parent',
+              children: [
+                { key: 'target', value: 'target', title: 'Target' },
+                { key: 'sibling', value: 'sibling', title: 'Sibling' },
+              ],
+            },
+            { key: 'other', value: 'other', title: 'Other root' },
+          ]}
+        />,
+      );
+      const getVisibleTitles = () => getVisibleTreeNodes(container).map(node => node.textContent);
+
+      expect(getVisibleTitles()).toEqual(['Parent', 'Other root']);
+
+      search(container, 'Target');
+      expect(getVisibleTitles()).toEqual(['Parent', 'Target']);
+
+      search(container, '');
+      expect(getVisibleTitles()).toEqual(['Parent', 'Other root']);
     });
 
     it('search nodes by filterTreeNode', () => {

--- a/tests/__snapshots__/Select.spec.tsx.snap
+++ b/tests/__snapshots__/Select.spec.tsx.snap
@@ -693,7 +693,7 @@ exports[`TreeSelect.basic search nodes check tree changed by filter 2`] = `
                   <div
                     aria-disabled="false"
                     aria-selected="false"
-                    class="rc-tree-select-tree-treenode rc-tree-select-tree-treenode-switcher-open rc-tree-select-tree-treenode-active rc-tree-select-tree-treenode-leaf"
+                    class="rc-tree-select-tree-treenode rc-tree-select-tree-treenode-switcher-close rc-tree-select-tree-treenode-active rc-tree-select-tree-treenode-leaf"
                     draggable="false"
                     id="test-id-a"
                     role="treeitem"


### PR DESCRIPTION
## Summary
- Raise the minimum @rc-component/tree version from ~1.5.0 to ~1.5.3 to include the controlled/uncontrolled state fixes in https://github.com/react-component/tree/pull/1069.
- Update the search-clear snapshot: releasing the search-controlled expandedKeys now resets expansion, so the leaf node no longer retains the switcher-open class.
- Add one behavior test covering automatic search expansion followed by clearing the search without manual expansion. It asserts the visible nodes rather than CSS classes.
- No TreeSelect production code changes or package version bump.

## Validation
Dependencies installed with pnpm; verified that @rc-component/tree resolves to 1.5.3.
- pnpm test --runInBand --silent: 12 suites, 185 tests, and 15 snapshots passed.
- Counterfactual check: the new behavior test fails with Tree 1.5.2 and passes with Tree 1.5.3.
- pnpm run tsc: passed.
- pnpm run lint: passed with 0 errors and 6 warnings in unchanged source/example files.
- Prettier checks for package.json and tests/Select.spec.tsx: passed.
- git diff --check: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复树组件中，搜索子节点后清空搜索内容时，节点展开状态未正确恢复的问题。
- **维护**
  - 更新树组件相关依赖版本，提升兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
